### PR TITLE
[Android] Add path constraint for running lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,16 @@
 name: Static code checks
 on:
   pull_request:
+    paths:
+      - 'android/'
+      - '.github/'
   merge_group:
     types: [checks_requested]
   push:
     branches: [ main ]
+    paths:
+      - 'android/'
+      - '.github/'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,15 +2,15 @@ name: Static code checks
 on:
   pull_request:
     paths:
-      - 'android/'
-      - '.github/'
+      - 'android/**'
+      - '.github/**'
   merge_group:
     types: [checks_requested]
   push:
     branches: [ main ]
     paths:
-      - 'android/'
-      - '.github/'
+      - 'android/**'
+      - '.github/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Ensures the lint checks only run when files within the `android` folder or the `.github` folder are changed.