### PR TITLE
Feature - add colour palette to swift package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,11 @@ The Typography fonts provided by this library are of type `GuardianFont`. Guardi
 1. Import framework - `import Source` 
 
 2. Use font modifier from `GuardianFonts` package - `.font(Typography.headlineBld14)`
+
+## ColorPalette
+This defines the brand colours from [Source documentation](https://design.theguardian.com/#colour-palette).
+
+### Usage
+
+1. Import framework - `import Source`
+2. Access colours like so - `ColorPalette.brand400`

--- a/Sources/Source/ColorPalette/ColorPalette.swift
+++ b/Sources/Source/ColorPalette/ColorPalette.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+/**
+ Module that defines the brand colours from [Source documentation](https://design.theguardian.com/#colour-palette).
+ This currently only holds references to the colours and extensions to assist with defining colours elsewhere.
+ */
+public enum ColorPalette {
+    public static let brand300 = UIColor.colorFromBundle(named: "Brand300")!
+    public static let brand400 = UIColor.colorFromBundle(named: "Brand400")!
+    public static let brand500 = UIColor.colorFromBundle(named: "Brand500")!
+    public static let brand600 = UIColor.colorFromBundle(named: "Brand600")!
+    public static let brand800 = UIColor.colorFromBundle(named: "Brand800")!
+    public static let brandAlt200 = UIColor.colorFromBundle(named: "BrandAlt200")!
+    public static let brandAlt400 = UIColor.colorFromBundle(named: "BrandAlt400")!
+    public static let neutral0 = UIColor.colorFromBundle(named: "Neutral0")!
+    public static let neutral7 = UIColor.colorFromBundle(named: "Neutral7")!
+    public static let neutral10 = UIColor.colorFromBundle(named: "Neutral10")!
+    public static let neutral20 = UIColor.colorFromBundle(named: "Neutral20")!
+    public static let neutral36 = UIColor.colorFromBundle(named: "Neutral36")!
+    public static let neutral38 = UIColor.colorFromBundle(named: "Neutral38")!
+    public static let neutral46 = UIColor.colorFromBundle(named: "Neutral46")!
+    public static let neutral60 = UIColor.colorFromBundle(named: "Neutral60")!
+    public static let neutral86 = UIColor.colorFromBundle(named: "Neutral86")!
+    public static let neutral93 = UIColor.colorFromBundle(named: "Neutral93")!
+    public static let neutral97 = UIColor.colorFromBundle(named: "Neutral97")!
+    public static let neutral100 = UIColor.colorFromBundle(named: "Neutral100")!
+    public static let culture700 = UIColor.colorFromBundle(named: "Culture700")!
+    public static let culture800 = UIColor.colorFromBundle(named: "Culture800")!
+    public static let sport400 = UIColor.colorFromBundle(named: "Sport400")!
+    public static let sport500 = UIColor.colorFromBundle(named: "Sport500")!
+}

--- a/Sources/Source/ColorPalette/Extensions/UIColor+Dynamic.swift
+++ b/Sources/Source/ColorPalette/Extensions/UIColor+Dynamic.swift
@@ -1,0 +1,24 @@
+//
+
+import UIKit
+
+public extension UIColor {
+    class func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+         UIColor {
+            switch $0.userInterfaceStyle {
+            case .dark:
+               return dark
+            default:
+               return light
+            }
+         }
+      }
+
+    // swiftlint: disable color_named_reference
+    class func colorFromBundle(named: String) -> UIColor? {
+        UIColor(named: named,
+                in: .module,
+                compatibleWith: .none)
+    }
+    // swiftlint: enable color_named_reference
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Brand300.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Brand300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4A",
+          "green" : "0x1F",
+          "red" : "0x04"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Brand400.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Brand400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x62",
+          "green" : "0x29",
+          "red" : "0x05"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Brand500.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Brand500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0x7A",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Brand600.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Brand600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x69",
+          "red" : "0x50"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Brand800.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Brand800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0xD8",
+          "red" : "0xC1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/BrandAlt200.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/BrandAlt200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xC1",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/BrandAlt400.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/BrandAlt400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xE5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Culture700.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Culture700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDD",
+          "green" : "0xE8",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Culture800.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Culture800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0xF6",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral0.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral0.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral10.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral100.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral20.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral36.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral36.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x60",
+          "green" : "0x60",
+          "red" : "0x60"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral38.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral38.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x60",
+          "green" : "0x60",
+          "red" : "0x60"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral46.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral46.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x76",
+          "green" : "0x76",
+          "red" : "0x76"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral60.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral60.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0x99",
+          "red" : "0x99"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral7.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral7.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral86.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral86.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDC",
+          "green" : "0xDC",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral93.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral93.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0xED",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Neutral97.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Neutral97.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF6",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Sport400.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Sport400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB6",
+          "green" : "0x77",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Sport500.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Sport500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xB2",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new `ColorPalette` class to the Source iOS swift package, for colour reference. It simply moves the code that previously existed inside the `ColorPalette` local swift package that lived in the main app previously. 

To test this you can check out this branch which update the live app to reference Guardian colours via Source - https://github.com/guardian/ios-live/tree/CQ/replace-colour-palette-with-Source-library. 
Once this has been merged, I will open a PR on the live app repo to replace the existing ColorPalette framework with the Source framework. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
