### PR TITLE
Run lint checks for android changes but pass for non-android changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,14 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
-      android: ${{ steps.changes.outputs.android }}
+      android: ${{ steps.filter.outputs.android }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
-      id: changes
+    - uses: dorny/paths-filter@v3
+      id: filter
       with:
         filters: |
           android:
@@ -28,6 +30,7 @@ jobs:
 
   lint:
     name: ktlint & gradle lint
+    needs: changes
     if: ${{ needs.changes.outputs.android == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -50,6 +53,7 @@ jobs:
 
   detekt:
     name: Detekt
+    needs: changes
     if: ${{ needs.changes.outputs.android == 'true' }}
     permissions: write-all
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,10 @@
 name: Static code checks
 on:
   pull_request:
-    paths:
-      - 'android/**'
-      - '.github/**'
   merge_group:
     types: [checks_requested]
   push:
     branches: [ main ]
-    paths:
-      - 'android/**'
-      - '.github/**'
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +12,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.changes.outputs.android }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          android:
+            - 'android/**'
+            - '.github/**'          
+
   lint:
     name: ktlint & gradle lint
+    if: ${{ needs.changes.outputs.android == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +50,7 @@ jobs:
 
   detekt:
     name: Detekt
+    if: ${{ needs.changes.outputs.android == 'true' }}
     permissions: write-all
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Using the path filter means the checks stay pending for iOS PRs. This replaces path filter with a job to check for `changes`. The lint jobs are dependent on the `changes` job, and are skipped if no changes found.

This makes the checks run on Android changes and passes quickly for iOS (or README) only changes.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
