### PR TITLE
Add nexus gradle publish plugin to auto close staging and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
             AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
           run: |
             cd android
-            ./gradlew :source:publishAllPublicationsToSonatypeRepository
+            ./gradlew :source:publishToSonatype closeAndReleaseSonatypeStagingRepository
+            # ./gradlew :source:publishAllPublicationsToSonatypeRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,3 @@ jobs:
           run: |
             cd android
             ./gradlew :source:publishToSonatype closeAndReleaseSonatypeStagingRepository
-            # ./gradlew :source:publishAllPublicationsToSonatypeRepository

--- a/android/README.md
+++ b/android/README.md
@@ -2,12 +2,9 @@
 
 # The Source library for Android
 
-> [!Note]
-> ~~This is an exploratory project as we evolve Source to support the apps, and the accompanying code infra.~~
-
 ### Using the library
 
-Add the library dependency:
+The library is available on Maven Central. Add the library dependency to your `build.gradle.kts` file:
 
 ```kotlin
 implementation("com.gu.source:source-android:0.0.1")
@@ -16,8 +13,6 @@ implementation("com.gu.source:source-android:0.0.1")
 See the main [README](../README.md) for using the library.
 
 ### Building and using as a bundled repo
-
-~~Please note: This is a temporary solution until we publish the library to mavencentral~~
 
 1. Build the library
    Run
@@ -31,6 +26,27 @@ See the main [README](../README.md) for using the library.
 
 3. Update the version number in the news app
    If the library version has changed, update it in the version catalog for the news app.
+
+### Building and using from maven local
+
+1. Build the library
+   Run
+   ```shell
+   ./gradlew :source:publishToMavenLocal
+   ```
+   This will publish the library to your local maven repository.
+
+2. Update the version number in the news app
+   If the library version has changed, update it in the version catalog for the news app.
+   
+3. Ensure you have `mavenLocal` declared first in your repositories
+   ```groovy
+   repositories {
+       mavenLocal()
+       mavenCentral()
+       google()
+   }
+   ```
 
 ### Other notes
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -13,6 +13,20 @@ plugins {
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.paparazzi) apply false
+    alias(libs.plugins.nexus.publish)
+}
+
+
+group = libs.versions.group.get()
+version = libs.versions.libraryVersion.get()
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = "guardian.automated.maven.release"
+            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD")
+        }
+    }
 }
 
 allprojects {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-libraryVersion = "0.1.0"
+group = "com.gu.source"
+libraryVersion = "0.1.1"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "33"
@@ -28,6 +29,7 @@ inject = "1"
 kotlinx-collections-immutable = "0.3.7"
 lifecycleRuntimeKtx = "2.7.0"
 lint-gradle = "1.0.0-alpha01"
+nexus-publish = "2.0.0"
 timber = "5.0.1"
 
 junit = "4.13.2"
@@ -91,6 +93,8 @@ agp-test = { id = "com.android.test", version.ref = "agp" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
+
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 
 # Guardian's convention plugins
 guardian-application = { id = "com.theguardian.application", version.ref = "guardian-convention-plugins" }

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -81,16 +81,19 @@ publishing {
     }
 
     repositories {
-        maven {
-            name = "sonatype"
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = "guardian.automated.maven.release"
-                password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD")
-            }
-        }
+        // This is commented out because we're using nexus publishing plugin to publish to Sonatype.
+        // That's configured in the root build.gradle.kts file.
+//        maven {
+//            name = "sonatype"
+//            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+//            credentials {
+//                username = "guardian.automated.maven.release"
+//                password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD")
+//            }
+//        }
 
         // Adds a task for publishing locally to the build directory.
+        // Use as `./gradlew :source:publishReleasePublicationToGusourceRepository`
         maven {
             name = "gusource"
             url = uri("${project.buildDir}/gusource")

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace = "com.gu.source"
+    namespace = libs.versions.group.get()
 
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")
@@ -39,7 +39,7 @@ dependencies {
 publishing {
     publications {
         register<MavenPublication>("release") {
-            groupId = "com.gu.source"
+            groupId = libs.versions.group.get()
             artifactId = "source-android"
             version = libs.versions.libraryVersion.get()
 

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -45,7 +45,7 @@ publishing {
 
             pom {
                 name.set("Source Android")
-                description.set("Guardian design system library for Android")
+                description.set("The Guardian's design system library for Android")
                 url.set("https://github.com/guardian/source-apps")
                 packaging = "aar"
                 licenses {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Switches to [Gradle nexus publish plugin](https://github.com/gradle-nexus/publish-plugin/) for publishing the library to Sonatype. This plugin supports immediately releasing the updates to production. The existing `maven-publish` based solution only uploads to staging. It required manual update to production by logging into Sonatype. The nexus plugin removes that manual step.

To test this, I updated the library version to `0.1.1` (from `0.1.0`) and [published it successfully](https://central.sonatype.com/artifact/com.gu.source/source-android).