### PR TITLE
Change from property to nested object pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Add the dependency to `build.gradle.kts` for the consuming module:
 implementation("com.gu.source:source-android:<version>")
 ```
 
-Alternatively, add it to your app's core design module as an `api` dependency. It will be transitively available to all other modules:
+<!-- Alternatively, add it to your app's core design module as an `api` dependency. It will be transitively available to all other modules:
 
 ```kotlin
 api("com.gu.source:source-android:<version>")
-```
+```-->
 
 > [!Note]
 > See [here](/android/README.md) if you need to build and bundle the library as a local repository.
 
 ## Using the library
 
-The library exposes a single object `com.gu.Source`. Design presets are available as properties on this object, e.g. `Source.typography.headlineBold15`.
+The library exposes a single object `com.gu.Source`. Design presets are available as properties on this object, e.g. `Source.Typography.headlineBold15`.
 
 The library bundles app font files, so they are not separately required in consumer apps.
 
@@ -40,17 +40,17 @@ Use typography presets directly in a `Text` component.
 ```kotlin
 Text(
     text = "The world's leading liberal voice",
-    style = Source.typography.textEgyptianItalic14,
+    style = Source.Typography.textEgyptianItalic14,
 )
 ```
 ### Core palette colours
 
-Core palette colours are available for direct use in components through `Source.palette`.
+Core palette colours are available for direct use in components through `Source.Palette`.
 
 ```kotlin
 Text(
     text = "The world's leading liberal voice",
-    color = Source.palette.brand_400,
+    color = Source.Palette.brand_400,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ api("com.gu.source:source-android:<version>")
 
 ## Using the library
 
-The library exposes a single object `com.gu.Source`. Design presets are available as properties on this object, e.g. `Source.Typography.headlineBold15`.
+The library exposes a single object `com.gu.Source`. Design presets are available as properties on this object, e.g. `Source.Typography.HeadlineBold15`.
 
 The library bundles app font files, so they are not separately required in consumer apps.
 
@@ -40,7 +40,7 @@ Use typography presets directly in a `Text` component.
 ```kotlin
 Text(
     text = "The world's leading liberal voice",
-    style = Source.Typography.textEgyptianItalic14,
+    style = Source.Typography.TextEgyptianItalic14,
 )
 ```
 ### Core palette colours
@@ -50,7 +50,7 @@ Core palette colours are available for direct use in components through `Source.
 ```kotlin
 Text(
     text = "The world's leading liberal voice",
-    color = Source.Palette.brand_400,
+    color = Source.Palette.Brand_400,
 )
 ```
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.1.1"
+libraryVersion = "0.1.2"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "33"

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.gu.source.presets.palette.brand_400
+import com.gu.source.presets.typography.textArticle17
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,8 +32,8 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
     Text(
         text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
         modifier = modifier,
-        style = Source.typography.textArticle17,
-        color = Source.palette.brand_400,
+        style = Source.Typography.textArticle17,
+        color = Source.Palette.brand_400,
     )
 }
 

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -10,8 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.gu.source.presets.palette.brand_400
-import com.gu.source.presets.typography.textArticle17
+import com.gu.source.presets.palette.Brand_400
+import com.gu.source.presets.typography.TextArticle17
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,8 +32,8 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
     Text(
         text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
         modifier = modifier,
-        style = Source.Typography.textArticle17,
-        color = Source.Palette.brand_400,
+        style = Source.Typography.TextArticle17,
+        color = Source.Palette.Brand_400,
     )
 }
 

--- a/android/source/src/main/kotlin/com/gu/source/Source.kt
+++ b/android/source/src/main/kotlin/com/gu/source/Source.kt
@@ -1,23 +1,31 @@
 package com.gu.source
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import com.gu.source.Source.typography
-import com.gu.source.presets.palette.Palette
-import com.gu.source.presets.typography.Typography
+import com.gu.source.Source.Palette
+import com.gu.source.Source.Typography
 
 /**
- * Source is the Guardian's design system. This object provides handles to tokens for colours(TBD),
- * [typography] and more.
+ * Source is the Guardian's design system. This object provides handles to tokens for [Typography],
+ * [Palette] and more.
  */
 object Source {
     /**
-     * [TextStyle] presets.
+     * App typography presets.
+     * The Guardian has four bespoke typefaces, which were created for different purposes. When
+     * used effectively, they create contrast and alter the tone in which text is read.
+     *
+     * **Where do we use app typography presets?**
+     * Any content crafted and developed within the app's native environment, including the app
+     * fronts, My Guardian, custom modals, and supporter revenue messages.
+     *
+     * Note: Article pages and sign-in/registration pages are presented in a webview, hence
+     * utilising web typography presets.
      */
-    val typography = Typography
+    object Typography
 
     /**
-     * Core [Color] palette tokens.
+     * App core colour palette.
+     *
+     * [Palette colour definitions](https://theguardian.design/2a1e5182b/p/71fb50-colour/b/399c59)).
      */
-    val palette = Palette
+    object Palette
 }

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -1,88 +1,148 @@
+@file:Suppress("UndocumentedPublicProperty", "UnusedReceiverParameter", "unused")
+
 package com.gu.source.presets.palette
 
 import androidx.compose.ui.graphics.Color
+import com.gu.source.Source
 
-/**
- * App core colour palette.
- *
- * [Palette colour definitions](https://theguardian.design/2a1e5182b/p/71fb50-colour/b/399c59)).
- */
-@Suppress("UndocumentedPublicProperty")
-object Palette {
-    val brand_100 = Color(color = 0xff001536)
-    val brand_300 = Color(color = 0xff041f4a)
-    val brand_400 = Color(color = 0xff052962)
-    val brand_500 = Color(color = 0xff007abc)
-    val brand_600 = Color(color = 0xff506991)
-    val brand_800 = Color(color = 0xffc1d8fc)
+val Source.Palette.brand_100: Color
+    get() = Color(color = 0xff001536)
+val Source.Palette.brand_300: Color
+    get() = Color(color = 0xff041f4a)
+val Source.Palette.brand_400: Color
+    get() = Color(color = 0xff052962)
+val Source.Palette.brand_500: Color
+    get() = Color(color = 0xff007abc)
+val Source.Palette.brand_600: Color
+    get() = Color(color = 0xff506991)
+val Source.Palette.brand_800: Color
+    get() = Color(color = 0xffc1d8fc)
 
-    val brandAlt_200 = Color(color = 0xfff3c100)
-    val brandAlt_300 = Color(color = 0xffffd900)
-    val brandAlt_400 = Color(color = 0xffffe500)
+val Source.Palette.brandAlt_200: Color
+    get() = Color(color = 0xfff3c100)
+val Source.Palette.brandAlt_300: Color
+    get() = Color(color = 0xffffd900)
+val Source.Palette.brandAlt_400: Color
+    get() = Color(color = 0xffffe500)
 
-    val neutral_0 = Color(color = 0xff000000)
-    val neutral_7 = Color(color = 0xff121212)
-    val neutral_10 = Color(color = 0xff1a1a1a)
-    val neutral_20 = Color(color = 0xff333333)
+val Source.Palette.neutral_0: Color
+    get() = Color(color = 0xff000000)
+val Source.Palette.neutral_7: Color
+    get() = Color(color = 0xff121212)
+val Source.Palette.neutral_10: Color
+    get() = Color(color = 0xff1a1a1a)
+val Source.Palette.neutral_20: Color
+    get() = Color(color = 0xff333333)
 
-    /** Was previously #606060. Updated to improve contrast for accessibility. */
-    val neutral_38 = Color(color = 0xff545454)
-    val neutral_46 = Color(color = 0xff707070)
-    val neutral_60 = Color(color = 0xff999999)
-    val neutral_73 = Color(color = 0xffbababa)
-    val neutral_86 = Color(color = 0xffdcdcdc)
-    val neutral_93 = Color(color = 0xffededed)
-    val neutral_97 = Color(color = 0xfff6f6f6)
-    val neutral_100 = Color(color = 0xffffffff)
+/** Was previously #606060. Updated to improve contrast for accessibility. */
+val Source.Palette.neutral_38: Color
+    get() = Color(color = 0xff545454)
+val Source.Palette.neutral_46: Color
+    get() = Color(color = 0xff707070)
+val Source.Palette.neutral_60: Color
+    get() = Color(color = 0xff999999)
+val Source.Palette.neutral_73: Color
+    get() = Color(color = 0xffbababa)
+val Source.Palette.neutral_86: Color
+    get() = Color(color = 0xffdcdcdc)
+val Source.Palette.neutral_93: Color
+    get() = Color(color = 0xffededed)
+val Source.Palette.neutral_97: Color
+    get() = Color(color = 0xfff6f6f6)
+val Source.Palette.neutral_100: Color
+    get() = Color(color = 0xffffffff)
 
-    val error_400 = Color(color = 0xffc70000)
-    val error_500 = Color(color = 0xffFF9081)
-    val success_400 = Color(color = 0xff22874d)
+val Source.Palette.error_400: Color
+    get() = Color(color = 0xffc70000)
+val Source.Palette.error_500: Color
+    get() = Color(color = 0xffFF9081)
+val Source.Palette.success_400: Color
+    get() = Color(color = 0xff22874d)
 
-    val news_100 = Color(color = 0xff660505)
-    val news_200 = Color(color = 0xff8b0000)
-    val news_300 = Color(color = 0xffab0613)
-    val news_400 = Color(color = 0xffc70000)
-    val news_500 = Color(color = 0xffff5943)
-    val news_600 = Color(color = 0xffffbac8)
-    val news_800 = Color(color = 0xfffff4f2)
+val Source.Palette.news_100: Color
+    get() = Color(color = 0xff660505)
+val Source.Palette.news_200: Color
+    get() = Color(color = 0xff8b0000)
+val Source.Palette.news_300: Color
+    get() = Color(color = 0xffab0613)
+val Source.Palette.news_400: Color
+    get() = Color(color = 0xffc70000)
+val Source.Palette.news_500: Color
+    get() = Color(color = 0xffff5943)
+val Source.Palette.news_600: Color
+    get() = Color(color = 0xffffbac8)
+val Source.Palette.news_800: Color
+    get() = Color(color = 0xfffff4f2)
 
-    val opinion_100 = Color(color = 0xff672005)
-    val opinion_200 = Color(color = 0xff8d2700)
-    val opinion_300 = Color(color = 0xffbd5318)
-    val opinion_400 = Color(color = 0xffe05e00)
-    val opinion_500 = Color(color = 0xffff7f0f)
-    val opinion_600 = Color(color = 0xfff9b376)
-    val opinion_800 = Color(color = 0xfffef9f5)
+val Source.Palette.opinion_100: Color
+    get() = Color(color = 0xff672005)
+val Source.Palette.opinion_200: Color
+    get() = Color(color = 0xff8d2700)
+val Source.Palette.opinion_300: Color
+    get() = Color(color = 0xffbd5318)
+val Source.Palette.opinion_400: Color
+    get() = Color(color = 0xffe05e00)
+val Source.Palette.opinion_500: Color
+    get() = Color(color = 0xffff7f0f)
+val Source.Palette.opinion_600: Color
+    get() = Color(color = 0xfff9b376)
+val Source.Palette.opinion_800: Color
+    get() = Color(color = 0xfffef9f5)
 
-    val sport_100 = Color(color = 0xff003c60)
-    val sport_200 = Color(color = 0xff004e7c)
-    val sport_300 = Color(color = 0xff005689)
-    val sport_400 = Color(color = 0xff0077B6)
-    val sport_500 = Color(color = 0xff00b2ff)
-    val sport_600 = Color(color = 0xff90dcff)
-    val sport_800 = Color(color = 0xfff1f8fc)
+val Source.Palette.sport_100: Color
+    get() = Color(color = 0xff003c60)
+val Source.Palette.sport_200: Color
+    get() = Color(color = 0xff004e7c)
+val Source.Palette.sport_300: Color
+    get() = Color(color = 0xff005689)
+val Source.Palette.sport_400: Color
+    get() = Color(color = 0xff0077B6)
+val Source.Palette.sport_500: Color
+    get() = Color(color = 0xff00b2ff)
+val Source.Palette.sport_600: Color
+    get() = Color(color = 0xff90dcff)
+val Source.Palette.sport_800: Color
+    get() = Color(color = 0xfff1f8fc)
 
-    val culture_100 = Color(color = 0xff3e3323)
-    val culture_200 = Color(color = 0xff574835)
-    val culture_300 = Color(color = 0xff6b5840)
-    val culture_400 = Color(color = 0xffa1845c)
-    val culture_500 = Color(color = 0xffeacca0)
-    val culture_600 = Color(color = 0xffe7d4b9)
-    val culture_800 = Color(color = 0xfffbf6ef)
+val Source.Palette.culture_100: Color
+    get() = Color(color = 0xff3e3323)
+val Source.Palette.culture_200: Color
+    get() = Color(color = 0xff574835)
+val Source.Palette.culture_300: Color
+    get() = Color(color = 0xff6b5840)
+val Source.Palette.culture_400: Color
+    get() = Color(color = 0xffa1845c)
+val Source.Palette.culture_500: Color
+    get() = Color(color = 0xffeacca0)
+val Source.Palette.culture_600: Color
+    get() = Color(color = 0xffe7d4b9)
+val Source.Palette.culture_800: Color
+    get() = Color(color = 0xfffbf6ef)
 
-    val lifestyle_100 = Color(color = 0xff510043)
-    val lifestyle_200 = Color(color = 0xff650054)
-    val lifestyle_300 = Color(color = 0xff7d0068)
-    val lifestyle_400 = Color(color = 0xffbb3b80)
-    val lifestyle_500 = Color(color = 0xffffabdb)
-    val lifestyle_600 = Color(color = 0xfffec8d3)
-    val lifestyle_800 = Color(color = 0xfffeeef7)
+val Source.Palette.lifestyle_100: Color
+    get() = Color(color = 0xff510043)
+val Source.Palette.lifestyle_200: Color
+    get() = Color(color = 0xff650054)
+val Source.Palette.lifestyle_300: Color
+    get() = Color(color = 0xff7d0068)
+val Source.Palette.lifestyle_400: Color
+    get() = Color(color = 0xffbb3b80)
+val Source.Palette.lifestyle_500: Color
+    get() = Color(color = 0xffffabdb)
+val Source.Palette.lifestyle_600: Color
+    get() = Color(color = 0xfffec8d3)
+val Source.Palette.lifestyle_800: Color
+    get() = Color(color = 0xfffeeef7)
 
-    val specialReport_100 = Color(color = 0xff222527)
-    val specialReport_200 = Color(color = 0xff303538)
-    val specialReport_300 = Color(color = 0xff3f464a)
-    val specialReport_400 = Color(color = 0xff63717a)
-    val specialReport_500 = Color(color = 0xffabc2c9)
-    val specialReport_800 = Color(color = 0xffeff1f2)
-}
+val Source.Palette.specialReport_100: Color
+    get() = Color(color = 0xff222527)
+val Source.Palette.specialReport_200: Color
+    get() = Color(color = 0xff303538)
+val Source.Palette.specialReport_300: Color
+    get() = Color(color = 0xff3f464a)
+val Source.Palette.specialReport_400: Color
+    get() = Color(color = 0xff63717a)
+val Source.Palette.specialReport_500: Color
+    get() = Color(color = 0xffabc2c9)
+val Source.Palette.specialReport_800: Color
+    get() = Color(color = 0xffeff1f2)

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -5,144 +5,144 @@ package com.gu.source.presets.palette
 import androidx.compose.ui.graphics.Color
 import com.gu.source.Source
 
-val Source.Palette.brand_100: Color
+val Source.Palette.Brand_100: Color
     get() = Color(color = 0xff001536)
-val Source.Palette.brand_300: Color
+val Source.Palette.Brand_300: Color
     get() = Color(color = 0xff041f4a)
-val Source.Palette.brand_400: Color
+val Source.Palette.Brand_400: Color
     get() = Color(color = 0xff052962)
-val Source.Palette.brand_500: Color
+val Source.Palette.Brand_500: Color
     get() = Color(color = 0xff007abc)
-val Source.Palette.brand_600: Color
+val Source.Palette.Brand_600: Color
     get() = Color(color = 0xff506991)
-val Source.Palette.brand_800: Color
+val Source.Palette.Brand_800: Color
     get() = Color(color = 0xffc1d8fc)
 
-val Source.Palette.brandAlt_200: Color
+val Source.Palette.BrandAlt_200: Color
     get() = Color(color = 0xfff3c100)
-val Source.Palette.brandAlt_300: Color
+val Source.Palette.BrandAlt_300: Color
     get() = Color(color = 0xffffd900)
-val Source.Palette.brandAlt_400: Color
+val Source.Palette.BrandAlt_400: Color
     get() = Color(color = 0xffffe500)
 
-val Source.Palette.neutral_0: Color
+val Source.Palette.Neutral_0: Color
     get() = Color(color = 0xff000000)
-val Source.Palette.neutral_7: Color
+val Source.Palette.Neutral_7: Color
     get() = Color(color = 0xff121212)
-val Source.Palette.neutral_10: Color
+val Source.Palette.Neutral_10: Color
     get() = Color(color = 0xff1a1a1a)
-val Source.Palette.neutral_20: Color
+val Source.Palette.Neutral_20: Color
     get() = Color(color = 0xff333333)
 
 /** Was previously #606060. Updated to improve contrast for accessibility. */
-val Source.Palette.neutral_38: Color
+val Source.Palette.Neutral_38: Color
     get() = Color(color = 0xff545454)
-val Source.Palette.neutral_46: Color
+val Source.Palette.Neutral_46: Color
     get() = Color(color = 0xff707070)
-val Source.Palette.neutral_60: Color
+val Source.Palette.Neutral_60: Color
     get() = Color(color = 0xff999999)
-val Source.Palette.neutral_73: Color
+val Source.Palette.Neutral_73: Color
     get() = Color(color = 0xffbababa)
-val Source.Palette.neutral_86: Color
+val Source.Palette.Neutral_86: Color
     get() = Color(color = 0xffdcdcdc)
-val Source.Palette.neutral_93: Color
+val Source.Palette.Neutral_93: Color
     get() = Color(color = 0xffededed)
-val Source.Palette.neutral_97: Color
+val Source.Palette.Neutral_97: Color
     get() = Color(color = 0xfff6f6f6)
-val Source.Palette.neutral_100: Color
+val Source.Palette.Neutral_100: Color
     get() = Color(color = 0xffffffff)
 
-val Source.Palette.error_400: Color
+val Source.Palette.Error_400: Color
     get() = Color(color = 0xffc70000)
-val Source.Palette.error_500: Color
+val Source.Palette.Error_500: Color
     get() = Color(color = 0xffFF9081)
-val Source.Palette.success_400: Color
+val Source.Palette.Success_400: Color
     get() = Color(color = 0xff22874d)
 
-val Source.Palette.news_100: Color
+val Source.Palette.News_100: Color
     get() = Color(color = 0xff660505)
-val Source.Palette.news_200: Color
+val Source.Palette.News_200: Color
     get() = Color(color = 0xff8b0000)
-val Source.Palette.news_300: Color
+val Source.Palette.News_300: Color
     get() = Color(color = 0xffab0613)
-val Source.Palette.news_400: Color
+val Source.Palette.News_400: Color
     get() = Color(color = 0xffc70000)
-val Source.Palette.news_500: Color
+val Source.Palette.News_500: Color
     get() = Color(color = 0xffff5943)
-val Source.Palette.news_600: Color
+val Source.Palette.News_600: Color
     get() = Color(color = 0xffffbac8)
-val Source.Palette.news_800: Color
+val Source.Palette.News_800: Color
     get() = Color(color = 0xfffff4f2)
 
-val Source.Palette.opinion_100: Color
+val Source.Palette.Opinion_100: Color
     get() = Color(color = 0xff672005)
-val Source.Palette.opinion_200: Color
+val Source.Palette.Opinion_200: Color
     get() = Color(color = 0xff8d2700)
-val Source.Palette.opinion_300: Color
+val Source.Palette.Opinion_300: Color
     get() = Color(color = 0xffbd5318)
-val Source.Palette.opinion_400: Color
+val Source.Palette.Opinion_400: Color
     get() = Color(color = 0xffe05e00)
-val Source.Palette.opinion_500: Color
+val Source.Palette.Opinion_500: Color
     get() = Color(color = 0xffff7f0f)
-val Source.Palette.opinion_600: Color
+val Source.Palette.Opinion_600: Color
     get() = Color(color = 0xfff9b376)
-val Source.Palette.opinion_800: Color
+val Source.Palette.Opinion_800: Color
     get() = Color(color = 0xfffef9f5)
 
-val Source.Palette.sport_100: Color
+val Source.Palette.Sport_100: Color
     get() = Color(color = 0xff003c60)
-val Source.Palette.sport_200: Color
+val Source.Palette.Sport_200: Color
     get() = Color(color = 0xff004e7c)
-val Source.Palette.sport_300: Color
+val Source.Palette.Sport_300: Color
     get() = Color(color = 0xff005689)
-val Source.Palette.sport_400: Color
+val Source.Palette.Sport_400: Color
     get() = Color(color = 0xff0077B6)
-val Source.Palette.sport_500: Color
+val Source.Palette.Sport_500: Color
     get() = Color(color = 0xff00b2ff)
-val Source.Palette.sport_600: Color
+val Source.Palette.Sport_600: Color
     get() = Color(color = 0xff90dcff)
-val Source.Palette.sport_800: Color
+val Source.Palette.Sport_800: Color
     get() = Color(color = 0xfff1f8fc)
 
-val Source.Palette.culture_100: Color
+val Source.Palette.Culture_100: Color
     get() = Color(color = 0xff3e3323)
-val Source.Palette.culture_200: Color
+val Source.Palette.Culture_200: Color
     get() = Color(color = 0xff574835)
-val Source.Palette.culture_300: Color
+val Source.Palette.Culture_300: Color
     get() = Color(color = 0xff6b5840)
-val Source.Palette.culture_400: Color
+val Source.Palette.Culture_400: Color
     get() = Color(color = 0xffa1845c)
-val Source.Palette.culture_500: Color
+val Source.Palette.Culture_500: Color
     get() = Color(color = 0xffeacca0)
-val Source.Palette.culture_600: Color
+val Source.Palette.Culture_600: Color
     get() = Color(color = 0xffe7d4b9)
-val Source.Palette.culture_800: Color
+val Source.Palette.Culture_800: Color
     get() = Color(color = 0xfffbf6ef)
 
-val Source.Palette.lifestyle_100: Color
+val Source.Palette.Lifestyle_100: Color
     get() = Color(color = 0xff510043)
-val Source.Palette.lifestyle_200: Color
+val Source.Palette.Lifestyle_200: Color
     get() = Color(color = 0xff650054)
-val Source.Palette.lifestyle_300: Color
+val Source.Palette.Lifestyle_300: Color
     get() = Color(color = 0xff7d0068)
-val Source.Palette.lifestyle_400: Color
+val Source.Palette.Lifestyle_400: Color
     get() = Color(color = 0xffbb3b80)
-val Source.Palette.lifestyle_500: Color
+val Source.Palette.Lifestyle_500: Color
     get() = Color(color = 0xffffabdb)
-val Source.Palette.lifestyle_600: Color
+val Source.Palette.Lifestyle_600: Color
     get() = Color(color = 0xfffec8d3)
-val Source.Palette.lifestyle_800: Color
+val Source.Palette.Lifestyle_800: Color
     get() = Color(color = 0xfffeeef7)
 
-val Source.Palette.specialReport_100: Color
+val Source.Palette.SpecialReport_100: Color
     get() = Color(color = 0xff222527)
-val Source.Palette.specialReport_200: Color
+val Source.Palette.SpecialReport_200: Color
     get() = Color(color = 0xff303538)
-val Source.Palette.specialReport_300: Color
+val Source.Palette.SpecialReport_300: Color
     get() = Color(color = 0xff3f464a)
-val Source.Palette.specialReport_400: Color
+val Source.Palette.SpecialReport_400: Color
     get() = Color(color = 0xff63717a)
-val Source.Palette.specialReport_500: Color
+val Source.Palette.SpecialReport_500: Color
     get() = Color(color = 0xffabc2c9)
-val Source.Palette.specialReport_800: Color
+val Source.Palette.SpecialReport_800: Color
     get() = Color(color = 0xffeff1f2)

--- a/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
@@ -13,7 +13,7 @@ import com.gu.source.Source
 import com.gu.source.utils.fontFamilyResource
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold14: TextStyle
+val Source.Typography.HeadlineBold14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._14,
@@ -24,7 +24,7 @@ val Source.Typography.headlineBold14: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold15: TextStyle
+val Source.Typography.HeadlineBold15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._15,
@@ -35,7 +35,7 @@ val Source.Typography.headlineBold15: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold16: TextStyle
+val Source.Typography.HeadlineBold16: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._16,
@@ -46,7 +46,7 @@ val Source.Typography.headlineBold16: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold17: TextStyle
+val Source.Typography.HeadlineBold17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._17,
@@ -57,7 +57,7 @@ val Source.Typography.headlineBold17: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold18: TextStyle
+val Source.Typography.HeadlineBold18: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._18,
@@ -68,7 +68,7 @@ val Source.Typography.headlineBold18: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold20: TextStyle
+val Source.Typography.HeadlineBold20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._20,
@@ -79,7 +79,7 @@ val Source.Typography.headlineBold20: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold22: TextStyle
+val Source.Typography.HeadlineBold22: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._22,
@@ -90,7 +90,7 @@ val Source.Typography.headlineBold22: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold24: TextStyle
+val Source.Typography.HeadlineBold24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._24,
@@ -101,7 +101,7 @@ val Source.Typography.headlineBold24: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold28: TextStyle
+val Source.Typography.HeadlineBold28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._28,
@@ -112,7 +112,7 @@ val Source.Typography.headlineBold28: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold34: TextStyle
+val Source.Typography.HeadlineBold34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._34,
@@ -123,7 +123,7 @@ val Source.Typography.headlineBold34: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineBold42: TextStyle
+val Source.Typography.HeadlineBold42: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
         fontSize = TextSize._42,
@@ -134,7 +134,7 @@ val Source.Typography.headlineBold42: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight14: TextStyle
+val Source.Typography.HeadlineLight14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._14,
@@ -145,7 +145,7 @@ val Source.Typography.headlineLight14: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight15: TextStyle
+val Source.Typography.HeadlineLight15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._15,
@@ -156,7 +156,7 @@ val Source.Typography.headlineLight15: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight16: TextStyle
+val Source.Typography.HeadlineLight16: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._16,
@@ -167,7 +167,7 @@ val Source.Typography.headlineLight16: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight17: TextStyle
+val Source.Typography.HeadlineLight17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._17,
@@ -178,7 +178,7 @@ val Source.Typography.headlineLight17: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight18: TextStyle
+val Source.Typography.HeadlineLight18: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._18,
@@ -189,7 +189,7 @@ val Source.Typography.headlineLight18: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight20: TextStyle
+val Source.Typography.HeadlineLight20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._20,
@@ -200,7 +200,7 @@ val Source.Typography.headlineLight20: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight22: TextStyle
+val Source.Typography.HeadlineLight22: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._22,
@@ -211,7 +211,7 @@ val Source.Typography.headlineLight22: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight24: TextStyle
+val Source.Typography.HeadlineLight24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._24,
@@ -222,7 +222,7 @@ val Source.Typography.headlineLight24: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight28: TextStyle
+val Source.Typography.HeadlineLight28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._28,
@@ -233,7 +233,7 @@ val Source.Typography.headlineLight28: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight34: TextStyle
+val Source.Typography.HeadlineLight34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._34,
@@ -244,7 +244,7 @@ val Source.Typography.headlineLight34: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineLight42: TextStyle
+val Source.Typography.HeadlineLight42: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
         fontSize = TextSize._42,
@@ -255,7 +255,7 @@ val Source.Typography.headlineLight42: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium14: TextStyle
+val Source.Typography.HeadlineMedium14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._14,
@@ -266,7 +266,7 @@ val Source.Typography.headlineMedium14: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium15: TextStyle
+val Source.Typography.HeadlineMedium15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._15,
@@ -277,7 +277,7 @@ val Source.Typography.headlineMedium15: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium16: TextStyle
+val Source.Typography.HeadlineMedium16: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._16,
@@ -288,7 +288,7 @@ val Source.Typography.headlineMedium16: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium17: TextStyle
+val Source.Typography.HeadlineMedium17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._17,
@@ -299,7 +299,7 @@ val Source.Typography.headlineMedium17: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium18: TextStyle
+val Source.Typography.HeadlineMedium18: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._18,
@@ -310,7 +310,7 @@ val Source.Typography.headlineMedium18: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium20: TextStyle
+val Source.Typography.HeadlineMedium20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._20,
@@ -321,7 +321,7 @@ val Source.Typography.headlineMedium20: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium22: TextStyle
+val Source.Typography.HeadlineMedium22: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._22,
@@ -332,7 +332,7 @@ val Source.Typography.headlineMedium22: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium24: TextStyle
+val Source.Typography.HeadlineMedium24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._24,
@@ -343,7 +343,7 @@ val Source.Typography.headlineMedium24: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium28: TextStyle
+val Source.Typography.HeadlineMedium28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._28,
@@ -354,7 +354,7 @@ val Source.Typography.headlineMedium28: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium34: TextStyle
+val Source.Typography.HeadlineMedium34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._34,
@@ -365,7 +365,7 @@ val Source.Typography.headlineMedium34: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMedium42: TextStyle
+val Source.Typography.HeadlineMedium42: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
         fontSize = TextSize._42,
@@ -376,7 +376,7 @@ val Source.Typography.headlineMedium42: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic14: TextStyle
+val Source.Typography.HeadlineMediumItalic14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._14,
@@ -387,7 +387,7 @@ val Source.Typography.headlineMediumItalic14: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic15: TextStyle
+val Source.Typography.HeadlineMediumItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._15,
@@ -398,7 +398,7 @@ val Source.Typography.headlineMediumItalic15: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic16: TextStyle
+val Source.Typography.HeadlineMediumItalic16: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._16,
@@ -409,7 +409,7 @@ val Source.Typography.headlineMediumItalic16: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic17: TextStyle
+val Source.Typography.HeadlineMediumItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._17,
@@ -420,7 +420,7 @@ val Source.Typography.headlineMediumItalic17: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic18: TextStyle
+val Source.Typography.HeadlineMediumItalic18: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._18,
@@ -431,7 +431,7 @@ val Source.Typography.headlineMediumItalic18: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic20: TextStyle
+val Source.Typography.HeadlineMediumItalic20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._20,
@@ -442,7 +442,7 @@ val Source.Typography.headlineMediumItalic20: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic22: TextStyle
+val Source.Typography.HeadlineMediumItalic22: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._22,
@@ -453,7 +453,7 @@ val Source.Typography.headlineMediumItalic22: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic24: TextStyle
+val Source.Typography.HeadlineMediumItalic24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._24,
@@ -464,7 +464,7 @@ val Source.Typography.headlineMediumItalic24: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic28: TextStyle
+val Source.Typography.HeadlineMediumItalic28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._28,
@@ -475,7 +475,7 @@ val Source.Typography.headlineMediumItalic28: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic34: TextStyle
+val Source.Typography.HeadlineMediumItalic34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._34,
@@ -486,7 +486,7 @@ val Source.Typography.headlineMediumItalic34: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineMediumItalic42: TextStyle
+val Source.Typography.HeadlineMediumItalic42: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
         fontSize = TextSize._42,
@@ -497,7 +497,7 @@ val Source.Typography.headlineMediumItalic42: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold14: TextStyle
+val Source.Typography.HeadlineSemiBold14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._14,
@@ -508,7 +508,7 @@ val Source.Typography.headlineSemiBold14: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold15: TextStyle
+val Source.Typography.HeadlineSemiBold15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._15,
@@ -519,7 +519,7 @@ val Source.Typography.headlineSemiBold15: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold16: TextStyle
+val Source.Typography.HeadlineSemiBold16: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._16,
@@ -530,7 +530,7 @@ val Source.Typography.headlineSemiBold16: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold18: TextStyle
+val Source.Typography.HeadlineSemiBold18: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._18,
@@ -541,7 +541,7 @@ val Source.Typography.headlineSemiBold18: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold24: TextStyle
+val Source.Typography.HeadlineSemiBold24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._24,
@@ -552,7 +552,7 @@ val Source.Typography.headlineSemiBold24: TextStyle
     )
 
 /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-val Source.Typography.headlineSemiBold28: TextStyle
+val Source.Typography.HeadlineSemiBold28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
         fontSize = TextSize._28,
@@ -563,7 +563,7 @@ val Source.Typography.headlineSemiBold28: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticle15: TextStyle
+val Source.Typography.TextArticle15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
         fontSize = TextSize._15,
@@ -574,7 +574,7 @@ val Source.Typography.textArticle15: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticle17: TextStyle
+val Source.Typography.TextArticle17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
         fontSize = TextSize._17,
@@ -585,7 +585,7 @@ val Source.Typography.textArticle17: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleBold15: TextStyle
+val Source.Typography.TextArticleBold15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
         fontSize = TextSize._15,
@@ -596,7 +596,7 @@ val Source.Typography.textArticleBold15: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleBold17: TextStyle
+val Source.Typography.TextArticleBold17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
         fontSize = TextSize._17,
@@ -607,7 +607,7 @@ val Source.Typography.textArticleBold17: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleItalic15: TextStyle
+val Source.Typography.TextArticleItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
         fontSize = TextSize._15,
@@ -618,7 +618,7 @@ val Source.Typography.textArticleItalic15: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleItalic17: TextStyle
+val Source.Typography.TextArticleItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
         fontSize = TextSize._17,
@@ -629,7 +629,7 @@ val Source.Typography.textArticleItalic17: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleBoldItalic15: TextStyle
+val Source.Typography.TextArticleBoldItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
         fontSize = TextSize._15,
@@ -640,7 +640,7 @@ val Source.Typography.textArticleBoldItalic15: TextStyle
     )
 
 /** Use for article body text. */
-val Source.Typography.textArticleBoldItalic17: TextStyle
+val Source.Typography.TextArticleBoldItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
         fontSize = TextSize._17,
@@ -651,7 +651,7 @@ val Source.Typography.textArticleBoldItalic17: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptian14: TextStyle
+val Source.Typography.TextEgyptian14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
         fontSize = TextSize._14,
@@ -662,7 +662,7 @@ val Source.Typography.textEgyptian14: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptian15: TextStyle
+val Source.Typography.TextEgyptian15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
         fontSize = TextSize._15,
@@ -673,7 +673,7 @@ val Source.Typography.textEgyptian15: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptian17: TextStyle
+val Source.Typography.TextEgyptian17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
         fontSize = TextSize._17,
@@ -685,7 +685,7 @@ val Source.Typography.textEgyptian17: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBold14: TextStyle
+val Source.Typography.TextEgyptianBold14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
         fontSize = TextSize._14,
@@ -697,7 +697,7 @@ val Source.Typography.textEgyptianBold14: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBold15: TextStyle
+val Source.Typography.TextEgyptianBold15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
         fontSize = TextSize._15,
@@ -709,7 +709,7 @@ val Source.Typography.textEgyptianBold15: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBold17: TextStyle
+val Source.Typography.TextEgyptianBold17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
         fontSize = TextSize._17,
@@ -721,7 +721,7 @@ val Source.Typography.textEgyptianBold17: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBoldItalic14: TextStyle
+val Source.Typography.TextEgyptianBoldItalic14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
         fontSize = TextSize._14,
@@ -733,7 +733,7 @@ val Source.Typography.textEgyptianBoldItalic14: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBoldItalic15: TextStyle
+val Source.Typography.TextEgyptianBoldItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
         fontSize = TextSize._15,
@@ -745,7 +745,7 @@ val Source.Typography.textEgyptianBoldItalic15: TextStyle
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
 // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-val Source.Typography.textEgyptianBoldItalic17: TextStyle
+val Source.Typography.TextEgyptianBoldItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
         fontSize = TextSize._17,
@@ -756,7 +756,7 @@ val Source.Typography.textEgyptianBoldItalic17: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptianItalic14: TextStyle
+val Source.Typography.TextEgyptianItalic14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
         fontSize = TextSize._14,
@@ -767,7 +767,7 @@ val Source.Typography.textEgyptianItalic14: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptianItalic15: TextStyle
+val Source.Typography.TextEgyptianItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
         fontSize = TextSize._15,
@@ -778,7 +778,7 @@ val Source.Typography.textEgyptianItalic15: TextStyle
     )
 
 /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-val Source.Typography.textEgyptianItalic17: TextStyle
+val Source.Typography.TextEgyptianItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
         fontSize = TextSize._17,
@@ -801,7 +801,7 @@ val Source.Typography.textEgyptianItalic17: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans11: TextStyle
+val Source.Typography.TextSans11: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._11,
@@ -824,7 +824,7 @@ val Source.Typography.textSans11: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans12: TextStyle
+val Source.Typography.TextSans12: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._12,
@@ -847,7 +847,7 @@ val Source.Typography.textSans12: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans14: TextStyle
+val Source.Typography.TextSans14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._14,
@@ -870,7 +870,7 @@ val Source.Typography.textSans14: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans15: TextStyle
+val Source.Typography.TextSans15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._15,
@@ -893,7 +893,7 @@ val Source.Typography.textSans15: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans17: TextStyle
+val Source.Typography.TextSans17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._17,
@@ -916,7 +916,7 @@ val Source.Typography.textSans17: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans20: TextStyle
+val Source.Typography.TextSans20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._20,
@@ -939,7 +939,7 @@ val Source.Typography.textSans20: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans24: TextStyle
+val Source.Typography.TextSans24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._24,
@@ -962,7 +962,7 @@ val Source.Typography.textSans24: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans28: TextStyle
+val Source.Typography.TextSans28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._28,
@@ -985,7 +985,7 @@ val Source.Typography.textSans28: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSans34: TextStyle
+val Source.Typography.TextSans34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._34,
@@ -1008,7 +1008,7 @@ val Source.Typography.textSans34: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold11: TextStyle
+val Source.Typography.TextSansBold11: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._11,
@@ -1031,7 +1031,7 @@ val Source.Typography.textSansBold11: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold12: TextStyle
+val Source.Typography.TextSansBold12: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._12,
@@ -1054,7 +1054,7 @@ val Source.Typography.textSansBold12: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold14: TextStyle
+val Source.Typography.TextSansBold14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._14,
@@ -1077,7 +1077,7 @@ val Source.Typography.textSansBold14: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold15: TextStyle
+val Source.Typography.TextSansBold15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._15,
@@ -1100,7 +1100,7 @@ val Source.Typography.textSansBold15: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold17: TextStyle
+val Source.Typography.TextSansBold17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._17,
@@ -1123,7 +1123,7 @@ val Source.Typography.textSansBold17: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold20: TextStyle
+val Source.Typography.TextSansBold20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._20,
@@ -1146,7 +1146,7 @@ val Source.Typography.textSansBold20: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold24: TextStyle
+val Source.Typography.TextSansBold24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._24,
@@ -1169,7 +1169,7 @@ val Source.Typography.textSansBold24: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold28: TextStyle
+val Source.Typography.TextSansBold28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._28,
@@ -1192,7 +1192,7 @@ val Source.Typography.textSansBold28: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansBold34: TextStyle
+val Source.Typography.TextSansBold34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._34,
@@ -1216,7 +1216,7 @@ val Source.Typography.textSansBold34: TextStyle
  * from editorial content.
  */
 // TODO: 12/04/2024 App doesn't have an italic text sans font so using regular
-val Source.Typography.textSansItalic11: TextStyle
+val Source.Typography.TextSansItalic11: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._11,
@@ -1239,7 +1239,7 @@ val Source.Typography.textSansItalic11: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic12: TextStyle
+val Source.Typography.TextSansItalic12: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._12,
@@ -1262,7 +1262,7 @@ val Source.Typography.textSansItalic12: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic14: TextStyle
+val Source.Typography.TextSansItalic14: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._14,
@@ -1285,7 +1285,7 @@ val Source.Typography.textSansItalic14: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic15: TextStyle
+val Source.Typography.TextSansItalic15: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._15,
@@ -1308,7 +1308,7 @@ val Source.Typography.textSansItalic15: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic17: TextStyle
+val Source.Typography.TextSansItalic17: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._17,
@@ -1331,7 +1331,7 @@ val Source.Typography.textSansItalic17: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic20: TextStyle
+val Source.Typography.TextSansItalic20: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._20,
@@ -1354,7 +1354,7 @@ val Source.Typography.textSansItalic20: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic24: TextStyle
+val Source.Typography.TextSansItalic24: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._24,
@@ -1377,7 +1377,7 @@ val Source.Typography.textSansItalic24: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic28: TextStyle
+val Source.Typography.TextSansItalic28: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._28,
@@ -1400,7 +1400,7 @@ val Source.Typography.textSansItalic28: TextStyle
  * _Note_: Text Sans is used across the board on paid content templates to help differentiate
  * from editorial content.
  */
-val Source.Typography.textSansItalic34: TextStyle
+val Source.Typography.TextSansItalic34: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._34,
@@ -1414,7 +1414,7 @@ val Source.Typography.textSansItalic34: TextStyle
  * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
  * and at large sizes only.
  */
-val Source.Typography.titlepiece42: TextStyle
+val Source.Typography.Titlepiece42: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._42,
@@ -1428,7 +1428,7 @@ val Source.Typography.titlepiece42: TextStyle
  * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
  * and at large sizes only.
  */
-val Source.Typography.titlepiece50: TextStyle
+val Source.Typography.Titlepiece50: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._50,
@@ -1442,7 +1442,7 @@ val Source.Typography.titlepiece50: TextStyle
  * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
  * and at large sizes only.
  */
-val Source.Typography.titlepiece70: TextStyle
+val Source.Typography.Titlepiece70: TextStyle
     get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._70,

--- a/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
@@ -1452,7 +1452,6 @@ val Source.Typography.titlepiece70: TextStyle
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-
 @Suppress("MagicNumber")
 private object LineHeight {
     const val Tight = 1.15f

--- a/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/typography/Typography.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedReceiverParameter", "unused")
+
 package com.gu.source.presets.typography
 
 import androidx.compose.ui.text.PlatformTextStyle
@@ -7,742 +9,800 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
 import com.gu.source.R
+import com.gu.source.Source
 import com.gu.source.utils.fontFamilyResource
 
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold16: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold18: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold20: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold22: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold24: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold28: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold34: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineBold42: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight16: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight18: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight20: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight22: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight24: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight28: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight34: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineLight42: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W300,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium16: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium18: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium20: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium22: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium24: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium28: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium34: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMedium42: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic16: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Tight * TextSize._17,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic18: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic20: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._20,
+        lineHeight = LineHeight.Tight * TextSize._20,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic22: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._22,
+        lineHeight = LineHeight.Tight * TextSize._22,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic24: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic28: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic34: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._34,
+        lineHeight = LineHeight.Tight * TextSize._34,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineMediumItalic42: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
+        fontSize = TextSize._42,
+        lineHeight = LineHeight.Tight * TextSize._42,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Tight * TextSize._14,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Tight * TextSize._15,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold16: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._16,
+        lineHeight = LineHeight.Tight * TextSize._16,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold18: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._18,
+        lineHeight = LineHeight.Tight * TextSize._18,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold24: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._24,
+        lineHeight = LineHeight.Tight * TextSize._24,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
+val Source.Typography.headlineSemiBold28: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
+        fontSize = TextSize._28,
+        lineHeight = LineHeight.Tight * TextSize._28,
+        fontWeight = FontWeight.W500,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticle15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticle17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleBold15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleBold17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleItalic15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleItalic17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleBoldItalic15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Loose * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for article body text. */
+val Source.Typography.textArticleBoldItalic17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Loose * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptian14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptian15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptian17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBold14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBold15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBold17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Normal,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBoldItalic14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBoldItalic15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+// TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
+val Source.Typography.textEgyptianBoldItalic17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W700,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptianItalic14: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._14,
+        lineHeight = LineHeight.Regular * TextSize._14,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptianItalic15: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._15,
+        lineHeight = LineHeight.Regular * TextSize._15,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
+val Source.Typography.textEgyptianItalic17: TextStyle
+    get() = TextStyle(
+        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
+        fontSize = TextSize._17,
+        lineHeight = LineHeight.Regular * TextSize._17,
+        fontWeight = FontWeight.W400,
+        fontStyle = FontStyle.Italic,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
 /**
- * App typography presets.
- * The Guardian has four bespoke typefaces, which were created for different purposes. When
- * used effectively, they create contrast and alter the tone in which text is read.
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
  *
- * **Where do we use app typography presets?**
- * Any content crafted and developed within the app's native environment, including the app
- * fronts, My Guardian, custom modals, and supporter revenue messages.
  *
- * Note: Article pages and sign-in/registration pages are presented in a webview, hence
- * utilising web typography presets.
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
  */
-@Suppress("LargeClass")
-object Typography {
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Tight * TextSize._14,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Tight * TextSize._15,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold16 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._16,
-        lineHeight = LineHeight.Tight * TextSize._16,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Tight * TextSize._17,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold18 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._18,
-        lineHeight = LineHeight.Tight * TextSize._18,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold20 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._20,
-        lineHeight = LineHeight.Tight * TextSize._20,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold22 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._22,
-        lineHeight = LineHeight.Tight * TextSize._22,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold24 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._24,
-        lineHeight = LineHeight.Tight * TextSize._24,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold28 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._28,
-        lineHeight = LineHeight.Tight * TextSize._28,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold34 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._34,
-        lineHeight = LineHeight.Tight * TextSize._34,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineBold42 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_bold),
-        fontSize = TextSize._42,
-        lineHeight = LineHeight.Tight * TextSize._42,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Tight * TextSize._14,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Tight * TextSize._15,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight16 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._16,
-        lineHeight = LineHeight.Tight * TextSize._16,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Tight * TextSize._17,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight18 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._18,
-        lineHeight = LineHeight.Tight * TextSize._18,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight20 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._20,
-        lineHeight = LineHeight.Tight * TextSize._20,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight22 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._22,
-        lineHeight = LineHeight.Tight * TextSize._22,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight24 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._24,
-        lineHeight = LineHeight.Tight * TextSize._24,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight28 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._28,
-        lineHeight = LineHeight.Tight * TextSize._28,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight34 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._34,
-        lineHeight = LineHeight.Tight * TextSize._34,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineLight42 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_light),
-        fontSize = TextSize._42,
-        lineHeight = LineHeight.Tight * TextSize._42,
-        fontWeight = FontWeight.W300,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Tight * TextSize._14,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Tight * TextSize._15,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium16 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._16,
-        lineHeight = LineHeight.Tight * TextSize._16,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Tight * TextSize._17,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium18 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._18,
-        lineHeight = LineHeight.Tight * TextSize._18,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium20 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._20,
-        lineHeight = LineHeight.Tight * TextSize._20,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium22 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._22,
-        lineHeight = LineHeight.Tight * TextSize._22,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium24 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._24,
-        lineHeight = LineHeight.Tight * TextSize._24,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium28 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._28,
-        lineHeight = LineHeight.Tight * TextSize._28,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium34 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._34,
-        lineHeight = LineHeight.Tight * TextSize._34,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMedium42 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_medium),
-        fontSize = TextSize._42,
-        lineHeight = LineHeight.Tight * TextSize._42,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Tight * TextSize._14,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Tight * TextSize._15,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic16 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._16,
-        lineHeight = LineHeight.Tight * TextSize._16,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Tight * TextSize._17,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic18 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._18,
-        lineHeight = LineHeight.Tight * TextSize._18,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic20 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._20,
-        lineHeight = LineHeight.Tight * TextSize._20,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic22 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._22,
-        lineHeight = LineHeight.Tight * TextSize._22,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic24 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._24,
-        lineHeight = LineHeight.Tight * TextSize._24,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic28 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._28,
-        lineHeight = LineHeight.Tight * TextSize._28,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic34 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._34,
-        lineHeight = LineHeight.Tight * TextSize._34,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineMediumItalic42 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_mediumitalic),
-        fontSize = TextSize._42,
-        lineHeight = LineHeight.Tight * TextSize._42,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Tight * TextSize._14,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Tight * TextSize._15,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold16 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._16,
-        lineHeight = LineHeight.Tight * TextSize._16,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold18 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._18,
-        lineHeight = LineHeight.Tight * TextSize._18,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold24 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._24,
-        lineHeight = LineHeight.Tight * TextSize._24,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for headlines, headings and any short form text like pull quotes, bylines and titles. */
-    val headlineSemiBold28 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.ghguardianheadline_semibold),
-        fontSize = TextSize._28,
-        lineHeight = LineHeight.Tight * TextSize._28,
-        fontWeight = FontWeight.W500,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticle15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Loose * TextSize._15,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticle17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Loose * TextSize._17,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleBold15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Loose * TextSize._15,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleBold17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Loose * TextSize._17,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleItalic15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Loose * TextSize._15,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleItalic17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Loose * TextSize._17,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleBoldItalic15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Loose * TextSize._15,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for article body text. */
-    val textArticleBoldItalic17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Loose * TextSize._17,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptian14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Regular * TextSize._14,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptian15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Regular * TextSize._15,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptian17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regular),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Regular * TextSize._17,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBold14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Regular * TextSize._14,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBold15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Regular * TextSize._15,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBold17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_medium),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Regular * TextSize._17,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Normal,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBoldItalic14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Regular * TextSize._14,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBoldItalic15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Regular * TextSize._15,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    // TODO: 12/04/2024 App doesn't have a bold Egyptian font so using medium
-    val textEgyptianBoldItalic17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_mediumitalic),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Regular * TextSize._17,
-        fontWeight = FontWeight.W700,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptianItalic14 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
-        fontSize = TextSize._14,
-        lineHeight = LineHeight.Regular * TextSize._14,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptianItalic15 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
-        fontSize = TextSize._15,
-        lineHeight = LineHeight.Regular * TextSize._15,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /** Use for multiple sentences/paragraphs of text, like paragraphs of text on marketing pages. */
-    val textEgyptianItalic17 = TextStyle(
-        fontFamily = fontFamilyResource(R.font.guardiantextegyptian_regularitalic),
-        fontSize = TextSize._17,
-        lineHeight = LineHeight.Regular * TextSize._17,
-        fontWeight = FontWeight.W400,
-        fontStyle = FontStyle.Italic,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans11 = TextStyle(
+val Source.Typography.textSans11: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._11,
         lineHeight = LineHeight.Regular * TextSize._11,
@@ -751,20 +811,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans12 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans12: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._12,
         lineHeight = LineHeight.Regular * TextSize._12,
@@ -773,20 +834,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans14 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans14: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._14,
         lineHeight = LineHeight.Regular * TextSize._14,
@@ -795,20 +857,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans15 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans15: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._15,
         lineHeight = LineHeight.Regular * TextSize._15,
@@ -817,20 +880,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans17 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans17: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._17,
         lineHeight = LineHeight.Regular * TextSize._17,
@@ -839,20 +903,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans20 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans20: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._20,
         lineHeight = LineHeight.Regular * TextSize._20,
@@ -861,20 +926,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans24 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans24: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._24,
         lineHeight = LineHeight.Regular * TextSize._24,
@@ -883,20 +949,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans28 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans28: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._28,
         lineHeight = LineHeight.Regular * TextSize._28,
@@ -905,20 +972,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSans34 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSans34: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._34,
         lineHeight = LineHeight.Regular * TextSize._34,
@@ -927,20 +995,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold11 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold11: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._11,
         lineHeight = LineHeight.Regular * TextSize._11,
@@ -949,20 +1018,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold12 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold12: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._12,
         lineHeight = LineHeight.Regular * TextSize._12,
@@ -971,20 +1041,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold14 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold14: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._14,
         lineHeight = LineHeight.Regular * TextSize._14,
@@ -993,20 +1064,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold15 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold15: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._15,
         lineHeight = LineHeight.Regular * TextSize._15,
@@ -1015,20 +1087,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold17 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold17: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._17,
         lineHeight = LineHeight.Regular * TextSize._17,
@@ -1037,20 +1110,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold20 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold20: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._20,
         lineHeight = LineHeight.Regular * TextSize._20,
@@ -1059,20 +1133,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold24 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold24: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._24,
         lineHeight = LineHeight.Regular * TextSize._24,
@@ -1081,20 +1156,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold28 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold28: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._28,
         lineHeight = LineHeight.Regular * TextSize._28,
@@ -1103,20 +1179,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansBold34 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansBold34: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_bold),
         fontSize = TextSize._34,
         lineHeight = LineHeight.Regular * TextSize._34,
@@ -1125,21 +1202,22 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    // TODO: 12/04/2024 App doesn't have an italic text sans font so using regular
-    val textSansItalic11 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+// TODO: 12/04/2024 App doesn't have an italic text sans font so using regular
+val Source.Typography.textSansItalic11: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._11,
         lineHeight = LineHeight.Regular * TextSize._11,
@@ -1148,20 +1226,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic12 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic12: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._12,
         lineHeight = LineHeight.Regular * TextSize._12,
@@ -1170,20 +1249,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic14 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic14: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._14,
         lineHeight = LineHeight.Regular * TextSize._14,
@@ -1192,20 +1272,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic15 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic15: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._15,
         lineHeight = LineHeight.Regular * TextSize._15,
@@ -1214,20 +1295,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic17 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic17: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._17,
         lineHeight = LineHeight.Regular * TextSize._17,
@@ -1236,20 +1318,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic20 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic20: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._20,
         lineHeight = LineHeight.Regular * TextSize._20,
@@ -1258,20 +1341,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic24 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic24: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._24,
         lineHeight = LineHeight.Regular * TextSize._24,
@@ -1280,20 +1364,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic28 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic28: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._28,
         lineHeight = LineHeight.Regular * TextSize._28,
@@ -1302,20 +1387,21 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for interactive page elements like buttons and text input fields and for meta
-     * information like datelines, image captions and data visualisations. Use for interactive
-     * page elements like buttons and text input fields and for meta information like datelines,
-     * image captions and data visualisations.Use for interactive page elements like buttons and
-     * text input fields and for meta information like datelines, image captions and data
-     * visualisations.Use for interactive page elements like buttons and text input fields and
-     * for meta information like datelines, image captions and data visualisations.
-     *
-     *
-     * _Note_: Text Sans is used across the board on paid content templates to help differentiate
-     * from editorial content.
-     */
-    val textSansItalic34 = TextStyle(
+/**
+ * Use for interactive page elements like buttons and text input fields and for meta
+ * information like datelines, image captions and data visualisations. Use for interactive
+ * page elements like buttons and text input fields and for meta information like datelines,
+ * image captions and data visualisations.Use for interactive page elements like buttons and
+ * text input fields and for meta information like datelines, image captions and data
+ * visualisations.Use for interactive page elements like buttons and text input fields and
+ * for meta information like datelines, image captions and data visualisations.
+ *
+ *
+ * _Note_: Text Sans is used across the board on paid content templates to help differentiate
+ * from editorial content.
+ */
+val Source.Typography.textSansItalic34: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.guardian_texsan_two_regular),
         fontSize = TextSize._34,
         lineHeight = LineHeight.Regular * TextSize._34,
@@ -1324,11 +1410,12 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
-     * and at large sizes only.
-     */
-    val titlepiece42 = TextStyle(
+/**
+ * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+ * and at large sizes only.
+ */
+val Source.Typography.titlepiece42: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._42,
         lineHeight = LineHeight.Tight * TextSize._42,
@@ -1337,11 +1424,12 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
-     * and at large sizes only.
-     */
-    val titlepiece50 = TextStyle(
+/**
+ * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+ * and at large sizes only.
+ */
+val Source.Typography.titlepiece50: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._50,
         lineHeight = LineHeight.Tight * TextSize._50,
@@ -1350,11 +1438,12 @@ object Typography {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    /**
-     * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
-     * and at large sizes only.
-     */
-    val titlepiece70 = TextStyle(
+/**
+ * Use for impact. Ideal for marketing messages, page headers and numerals. Use sparingly
+ * and at large sizes only.
+ */
+val Source.Typography.titlepiece70: TextStyle
+    get() = TextStyle(
         fontFamily = fontFamilyResource(R.font.gtguardiantitlepiece_bold),
         fontSize = TextSize._70,
         lineHeight = LineHeight.Tight * TextSize._70,
@@ -1362,7 +1451,7 @@ object Typography {
         fontStyle = FontStyle.Normal,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
-}
+
 
 @Suppress("MagicNumber")
 private object LineHeight {

--- a/android/source/src/main/kotlin/com/gu/source/presets/typography/TypographyPreview.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/typography/TypographyPreview.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.gu.source.Source
 
 @OptIn(ExperimentalLayoutApi::class)
 @Preview(device = Devices.PIXEL_C, showBackground = true, backgroundColor = 0xFFFFFFFF)
@@ -19,67 +20,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineBold14",
-                style = Typography.headlineBold14,
+                style = Source.Typography.headlineBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold15",
-                style = Typography.headlineBold15,
+                style = Source.Typography.headlineBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold16",
-                style = Typography.headlineBold16,
+                style = Source.Typography.headlineBold16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold17",
-                style = Typography.headlineBold17,
+                style = Source.Typography.headlineBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold18",
-                style = Typography.headlineBold18,
+                style = Source.Typography.headlineBold18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold20",
-                style = Typography.headlineBold20,
+                style = Source.Typography.headlineBold20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold22",
-                style = Typography.headlineBold22,
+                style = Source.Typography.headlineBold22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold24",
-                style = Typography.headlineBold24,
+                style = Source.Typography.headlineBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold28",
-                style = Typography.headlineBold28,
+                style = Source.Typography.headlineBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold34",
-                style = Typography.headlineBold34,
+                style = Source.Typography.headlineBold34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold42",
-                style = Typography.headlineBold42,
+                style = Source.Typography.headlineBold42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -87,67 +88,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineLight14",
-                style = Typography.headlineLight14,
+                style = Source.Typography.headlineLight14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight15",
-                style = Typography.headlineLight15,
+                style = Source.Typography.headlineLight15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight16",
-                style = Typography.headlineLight16,
+                style = Source.Typography.headlineLight16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight17",
-                style = Typography.headlineLight17,
+                style = Source.Typography.headlineLight17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight18",
-                style = Typography.headlineLight18,
+                style = Source.Typography.headlineLight18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight20",
-                style = Typography.headlineLight20,
+                style = Source.Typography.headlineLight20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight22",
-                style = Typography.headlineLight22,
+                style = Source.Typography.headlineLight22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight24",
-                style = Typography.headlineLight24,
+                style = Source.Typography.headlineLight24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight28",
-                style = Typography.headlineLight28,
+                style = Source.Typography.headlineLight28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight34",
-                style = Typography.headlineLight34,
+                style = Source.Typography.headlineLight34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight42",
-                style = Typography.headlineLight42,
+                style = Source.Typography.headlineLight42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -155,67 +156,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineMedium14",
-                style = Typography.headlineMedium14,
+                style = Source.Typography.headlineMedium14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium15",
-                style = Typography.headlineMedium15,
+                style = Source.Typography.headlineMedium15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium16",
-                style = Typography.headlineMedium16,
+                style = Source.Typography.headlineMedium16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium17",
-                style = Typography.headlineMedium17,
+                style = Source.Typography.headlineMedium17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium18",
-                style = Typography.headlineMedium18,
+                style = Source.Typography.headlineMedium18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium20",
-                style = Typography.headlineMedium20,
+                style = Source.Typography.headlineMedium20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium22",
-                style = Typography.headlineMedium22,
+                style = Source.Typography.headlineMedium22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium24",
-                style = Typography.headlineMedium24,
+                style = Source.Typography.headlineMedium24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium28",
-                style = Typography.headlineMedium28,
+                style = Source.Typography.headlineMedium28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium34",
-                style = Typography.headlineMedium34,
+                style = Source.Typography.headlineMedium34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium42",
-                style = Typography.headlineMedium42,
+                style = Source.Typography.headlineMedium42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -223,67 +224,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineMediumItalic14",
-                style = Typography.headlineMediumItalic14,
+                style = Source.Typography.headlineMediumItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic15",
-                style = Typography.headlineMediumItalic15,
+                style = Source.Typography.headlineMediumItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic16",
-                style = Typography.headlineMediumItalic16,
+                style = Source.Typography.headlineMediumItalic16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic17",
-                style = Typography.headlineMediumItalic17,
+                style = Source.Typography.headlineMediumItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic18",
-                style = Typography.headlineMediumItalic18,
+                style = Source.Typography.headlineMediumItalic18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic20",
-                style = Typography.headlineMediumItalic20,
+                style = Source.Typography.headlineMediumItalic20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic22",
-                style = Typography.headlineMediumItalic22,
+                style = Source.Typography.headlineMediumItalic22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic24",
-                style = Typography.headlineMediumItalic24,
+                style = Source.Typography.headlineMediumItalic24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic28",
-                style = Typography.headlineMediumItalic28,
+                style = Source.Typography.headlineMediumItalic28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic34",
-                style = Typography.headlineMediumItalic34,
+                style = Source.Typography.headlineMediumItalic34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic42",
-                style = Typography.headlineMediumItalic42,
+                style = Source.Typography.headlineMediumItalic42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -291,37 +292,37 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineSemiBold14",
-                style = Typography.headlineSemiBold14,
+                style = Source.Typography.headlineSemiBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold15",
-                style = Typography.headlineSemiBold15,
+                style = Source.Typography.headlineSemiBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold16",
-                style = Typography.headlineSemiBold16,
+                style = Source.Typography.headlineSemiBold16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold18",
-                style = Typography.headlineSemiBold18,
+                style = Source.Typography.headlineSemiBold18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold24",
-                style = Typography.headlineSemiBold24,
+                style = Source.Typography.headlineSemiBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold28",
-                style = Typography.headlineSemiBold28,
+                style = Source.Typography.headlineSemiBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -329,49 +330,49 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textArticle15",
-                style = Typography.textArticle15,
+                style = Source.Typography.textArticle15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticle17",
-                style = Typography.textArticle17,
+                style = Source.Typography.textArticle17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBold15",
-                style = Typography.textArticleBold15,
+                style = Source.Typography.textArticleBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBold17",
-                style = Typography.textArticleBold17,
+                style = Source.Typography.textArticleBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleItalic15",
-                style = Typography.textArticleItalic15,
+                style = Source.Typography.textArticleItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleItalic17",
-                style = Typography.textArticleItalic17,
+                style = Source.Typography.textArticleItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBoldItalic15",
-                style = Typography.textArticleBoldItalic15,
+                style = Source.Typography.textArticleBoldItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBoldItalic17",
-                style = Typography.textArticleBoldItalic17,
+                style = Source.Typography.textArticleBoldItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -379,73 +380,73 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textEgyptian14",
-                style = Typography.textEgyptian14,
+                style = Source.Typography.textEgyptian14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptian15",
-                style = Typography.textEgyptian15,
+                style = Source.Typography.textEgyptian15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptian17",
-                style = Typography.textEgyptian17,
+                style = Source.Typography.textEgyptian17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold14",
-                style = Typography.textEgyptianBold14,
+                style = Source.Typography.textEgyptianBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold15",
-                style = Typography.textEgyptianBold15,
+                style = Source.Typography.textEgyptianBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold17",
-                style = Typography.textEgyptianBold17,
+                style = Source.Typography.textEgyptianBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic14",
-                style = Typography.textEgyptianBoldItalic14,
+                style = Source.Typography.textEgyptianBoldItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic15",
-                style = Typography.textEgyptianBoldItalic15,
+                style = Source.Typography.textEgyptianBoldItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic17",
-                style = Typography.textEgyptianBoldItalic17,
+                style = Source.Typography.textEgyptianBoldItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic14",
-                style = Typography.textEgyptianItalic14,
+                style = Source.Typography.textEgyptianItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic15",
-                style = Typography.textEgyptianItalic15,
+                style = Source.Typography.textEgyptianItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic17",
-                style = Typography.textEgyptianItalic17,
+                style = Source.Typography.textEgyptianItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -453,55 +454,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSans11",
-                style = Typography.textSans11,
+                style = Source.Typography.textSans11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans12",
-                style = Typography.textSans12,
+                style = Source.Typography.textSans12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans14",
-                style = Typography.textSans14,
+                style = Source.Typography.textSans14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans15",
-                style = Typography.textSans15,
+                style = Source.Typography.textSans15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans17",
-                style = Typography.textSans17,
+                style = Source.Typography.textSans17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans20",
-                style = Typography.textSans20,
+                style = Source.Typography.textSans20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans24",
-                style = Typography.textSans24,
+                style = Source.Typography.textSans24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans28",
-                style = Typography.textSans28,
+                style = Source.Typography.textSans28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans34",
-                style = Typography.textSans34,
+                style = Source.Typography.textSans34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -509,55 +510,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSansBold11",
-                style = Typography.textSansBold11,
+                style = Source.Typography.textSansBold11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold12",
-                style = Typography.textSansBold12,
+                style = Source.Typography.textSansBold12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold14",
-                style = Typography.textSansBold14,
+                style = Source.Typography.textSansBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold15",
-                style = Typography.textSansBold15,
+                style = Source.Typography.textSansBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold17",
-                style = Typography.textSansBold17,
+                style = Source.Typography.textSansBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold20",
-                style = Typography.textSansBold20,
+                style = Source.Typography.textSansBold20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold24",
-                style = Typography.textSansBold24,
+                style = Source.Typography.textSansBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold28",
-                style = Typography.textSansBold28,
+                style = Source.Typography.textSansBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold34",
-                style = Typography.textSansBold34,
+                style = Source.Typography.textSansBold34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -565,55 +566,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSansItalic11",
-                style = Typography.textSansItalic11,
+                style = Source.Typography.textSansItalic11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic12",
-                style = Typography.textSansItalic12,
+                style = Source.Typography.textSansItalic12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic14",
-                style = Typography.textSansItalic14,
+                style = Source.Typography.textSansItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic15",
-                style = Typography.textSansItalic15,
+                style = Source.Typography.textSansItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic17",
-                style = Typography.textSansItalic17,
+                style = Source.Typography.textSansItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic20",
-                style = Typography.textSansItalic20,
+                style = Source.Typography.textSansItalic20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic24",
-                style = Typography.textSansItalic24,
+                style = Source.Typography.textSansItalic24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic28",
-                style = Typography.textSansItalic28,
+                style = Source.Typography.textSansItalic28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic34",
-                style = Typography.textSansItalic34,
+                style = Source.Typography.textSansItalic34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -621,19 +622,19 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "titlepiece42",
-                style = Typography.titlepiece42,
+                style = Source.Typography.titlepiece42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "titlepiece50",
-                style = Typography.titlepiece50,
+                style = Source.Typography.titlepiece50,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "titlepiece70",
-                style = Typography.titlepiece70,
+                style = Source.Typography.titlepiece70,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }

--- a/android/source/src/main/kotlin/com/gu/source/presets/typography/TypographyPreview.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/typography/TypographyPreview.kt
@@ -20,67 +20,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineBold14",
-                style = Source.Typography.headlineBold14,
+                style = Source.Typography.HeadlineBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold15",
-                style = Source.Typography.headlineBold15,
+                style = Source.Typography.HeadlineBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold16",
-                style = Source.Typography.headlineBold16,
+                style = Source.Typography.HeadlineBold16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold17",
-                style = Source.Typography.headlineBold17,
+                style = Source.Typography.HeadlineBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold18",
-                style = Source.Typography.headlineBold18,
+                style = Source.Typography.HeadlineBold18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold20",
-                style = Source.Typography.headlineBold20,
+                style = Source.Typography.HeadlineBold20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold22",
-                style = Source.Typography.headlineBold22,
+                style = Source.Typography.HeadlineBold22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold24",
-                style = Source.Typography.headlineBold24,
+                style = Source.Typography.HeadlineBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold28",
-                style = Source.Typography.headlineBold28,
+                style = Source.Typography.HeadlineBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold34",
-                style = Source.Typography.headlineBold34,
+                style = Source.Typography.HeadlineBold34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineBold42",
-                style = Source.Typography.headlineBold42,
+                style = Source.Typography.HeadlineBold42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -88,67 +88,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineLight14",
-                style = Source.Typography.headlineLight14,
+                style = Source.Typography.HeadlineLight14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight15",
-                style = Source.Typography.headlineLight15,
+                style = Source.Typography.HeadlineLight15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight16",
-                style = Source.Typography.headlineLight16,
+                style = Source.Typography.HeadlineLight16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight17",
-                style = Source.Typography.headlineLight17,
+                style = Source.Typography.HeadlineLight17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight18",
-                style = Source.Typography.headlineLight18,
+                style = Source.Typography.HeadlineLight18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight20",
-                style = Source.Typography.headlineLight20,
+                style = Source.Typography.HeadlineLight20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight22",
-                style = Source.Typography.headlineLight22,
+                style = Source.Typography.HeadlineLight22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight24",
-                style = Source.Typography.headlineLight24,
+                style = Source.Typography.HeadlineLight24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight28",
-                style = Source.Typography.headlineLight28,
+                style = Source.Typography.HeadlineLight28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight34",
-                style = Source.Typography.headlineLight34,
+                style = Source.Typography.HeadlineLight34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineLight42",
-                style = Source.Typography.headlineLight42,
+                style = Source.Typography.HeadlineLight42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -156,67 +156,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineMedium14",
-                style = Source.Typography.headlineMedium14,
+                style = Source.Typography.HeadlineMedium14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium15",
-                style = Source.Typography.headlineMedium15,
+                style = Source.Typography.HeadlineMedium15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium16",
-                style = Source.Typography.headlineMedium16,
+                style = Source.Typography.HeadlineMedium16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium17",
-                style = Source.Typography.headlineMedium17,
+                style = Source.Typography.HeadlineMedium17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium18",
-                style = Source.Typography.headlineMedium18,
+                style = Source.Typography.HeadlineMedium18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium20",
-                style = Source.Typography.headlineMedium20,
+                style = Source.Typography.HeadlineMedium20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium22",
-                style = Source.Typography.headlineMedium22,
+                style = Source.Typography.HeadlineMedium22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium24",
-                style = Source.Typography.headlineMedium24,
+                style = Source.Typography.HeadlineMedium24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium28",
-                style = Source.Typography.headlineMedium28,
+                style = Source.Typography.HeadlineMedium28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium34",
-                style = Source.Typography.headlineMedium34,
+                style = Source.Typography.HeadlineMedium34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMedium42",
-                style = Source.Typography.headlineMedium42,
+                style = Source.Typography.HeadlineMedium42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -224,67 +224,67 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineMediumItalic14",
-                style = Source.Typography.headlineMediumItalic14,
+                style = Source.Typography.HeadlineMediumItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic15",
-                style = Source.Typography.headlineMediumItalic15,
+                style = Source.Typography.HeadlineMediumItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic16",
-                style = Source.Typography.headlineMediumItalic16,
+                style = Source.Typography.HeadlineMediumItalic16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic17",
-                style = Source.Typography.headlineMediumItalic17,
+                style = Source.Typography.HeadlineMediumItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic18",
-                style = Source.Typography.headlineMediumItalic18,
+                style = Source.Typography.HeadlineMediumItalic18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic20",
-                style = Source.Typography.headlineMediumItalic20,
+                style = Source.Typography.HeadlineMediumItalic20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic22",
-                style = Source.Typography.headlineMediumItalic22,
+                style = Source.Typography.HeadlineMediumItalic22,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic24",
-                style = Source.Typography.headlineMediumItalic24,
+                style = Source.Typography.HeadlineMediumItalic24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic28",
-                style = Source.Typography.headlineMediumItalic28,
+                style = Source.Typography.HeadlineMediumItalic28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic34",
-                style = Source.Typography.headlineMediumItalic34,
+                style = Source.Typography.HeadlineMediumItalic34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineMediumItalic42",
-                style = Source.Typography.headlineMediumItalic42,
+                style = Source.Typography.HeadlineMediumItalic42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -292,37 +292,37 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "headlineSemiBold14",
-                style = Source.Typography.headlineSemiBold14,
+                style = Source.Typography.HeadlineSemiBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold15",
-                style = Source.Typography.headlineSemiBold15,
+                style = Source.Typography.HeadlineSemiBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold16",
-                style = Source.Typography.headlineSemiBold16,
+                style = Source.Typography.HeadlineSemiBold16,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold18",
-                style = Source.Typography.headlineSemiBold18,
+                style = Source.Typography.HeadlineSemiBold18,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold24",
-                style = Source.Typography.headlineSemiBold24,
+                style = Source.Typography.HeadlineSemiBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "headlineSemiBold28",
-                style = Source.Typography.headlineSemiBold28,
+                style = Source.Typography.HeadlineSemiBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -330,49 +330,49 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textArticle15",
-                style = Source.Typography.textArticle15,
+                style = Source.Typography.TextArticle15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticle17",
-                style = Source.Typography.textArticle17,
+                style = Source.Typography.TextArticle17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBold15",
-                style = Source.Typography.textArticleBold15,
+                style = Source.Typography.TextArticleBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBold17",
-                style = Source.Typography.textArticleBold17,
+                style = Source.Typography.TextArticleBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleItalic15",
-                style = Source.Typography.textArticleItalic15,
+                style = Source.Typography.TextArticleItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleItalic17",
-                style = Source.Typography.textArticleItalic17,
+                style = Source.Typography.TextArticleItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBoldItalic15",
-                style = Source.Typography.textArticleBoldItalic15,
+                style = Source.Typography.TextArticleBoldItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textArticleBoldItalic17",
-                style = Source.Typography.textArticleBoldItalic17,
+                style = Source.Typography.TextArticleBoldItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -380,73 +380,73 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textEgyptian14",
-                style = Source.Typography.textEgyptian14,
+                style = Source.Typography.TextEgyptian14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptian15",
-                style = Source.Typography.textEgyptian15,
+                style = Source.Typography.TextEgyptian15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptian17",
-                style = Source.Typography.textEgyptian17,
+                style = Source.Typography.TextEgyptian17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold14",
-                style = Source.Typography.textEgyptianBold14,
+                style = Source.Typography.TextEgyptianBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold15",
-                style = Source.Typography.textEgyptianBold15,
+                style = Source.Typography.TextEgyptianBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBold17",
-                style = Source.Typography.textEgyptianBold17,
+                style = Source.Typography.TextEgyptianBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic14",
-                style = Source.Typography.textEgyptianBoldItalic14,
+                style = Source.Typography.TextEgyptianBoldItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic15",
-                style = Source.Typography.textEgyptianBoldItalic15,
+                style = Source.Typography.TextEgyptianBoldItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianBoldItalic17",
-                style = Source.Typography.textEgyptianBoldItalic17,
+                style = Source.Typography.TextEgyptianBoldItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic14",
-                style = Source.Typography.textEgyptianItalic14,
+                style = Source.Typography.TextEgyptianItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic15",
-                style = Source.Typography.textEgyptianItalic15,
+                style = Source.Typography.TextEgyptianItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textEgyptianItalic17",
-                style = Source.Typography.textEgyptianItalic17,
+                style = Source.Typography.TextEgyptianItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -454,55 +454,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSans11",
-                style = Source.Typography.textSans11,
+                style = Source.Typography.TextSans11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans12",
-                style = Source.Typography.textSans12,
+                style = Source.Typography.TextSans12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans14",
-                style = Source.Typography.textSans14,
+                style = Source.Typography.TextSans14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans15",
-                style = Source.Typography.textSans15,
+                style = Source.Typography.TextSans15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans17",
-                style = Source.Typography.textSans17,
+                style = Source.Typography.TextSans17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans20",
-                style = Source.Typography.textSans20,
+                style = Source.Typography.TextSans20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans24",
-                style = Source.Typography.textSans24,
+                style = Source.Typography.TextSans24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans28",
-                style = Source.Typography.textSans28,
+                style = Source.Typography.TextSans28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSans34",
-                style = Source.Typography.textSans34,
+                style = Source.Typography.TextSans34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -510,55 +510,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSansBold11",
-                style = Source.Typography.textSansBold11,
+                style = Source.Typography.TextSansBold11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold12",
-                style = Source.Typography.textSansBold12,
+                style = Source.Typography.TextSansBold12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold14",
-                style = Source.Typography.textSansBold14,
+                style = Source.Typography.TextSansBold14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold15",
-                style = Source.Typography.textSansBold15,
+                style = Source.Typography.TextSansBold15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold17",
-                style = Source.Typography.textSansBold17,
+                style = Source.Typography.TextSansBold17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold20",
-                style = Source.Typography.textSansBold20,
+                style = Source.Typography.TextSansBold20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold24",
-                style = Source.Typography.textSansBold24,
+                style = Source.Typography.TextSansBold24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold28",
-                style = Source.Typography.textSansBold28,
+                style = Source.Typography.TextSansBold28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansBold34",
-                style = Source.Typography.textSansBold34,
+                style = Source.Typography.TextSansBold34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -566,55 +566,55 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "textSansItalic11",
-                style = Source.Typography.textSansItalic11,
+                style = Source.Typography.TextSansItalic11,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic12",
-                style = Source.Typography.textSansItalic12,
+                style = Source.Typography.TextSansItalic12,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic14",
-                style = Source.Typography.textSansItalic14,
+                style = Source.Typography.TextSansItalic14,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic15",
-                style = Source.Typography.textSansItalic15,
+                style = Source.Typography.TextSansItalic15,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic17",
-                style = Source.Typography.textSansItalic17,
+                style = Source.Typography.TextSansItalic17,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic20",
-                style = Source.Typography.textSansItalic20,
+                style = Source.Typography.TextSansItalic20,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic24",
-                style = Source.Typography.textSansItalic24,
+                style = Source.Typography.TextSansItalic24,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic28",
-                style = Source.Typography.textSansItalic28,
+                style = Source.Typography.TextSansItalic28,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "textSansItalic34",
-                style = Source.Typography.textSansItalic34,
+                style = Source.Typography.TextSansItalic34,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
@@ -622,19 +622,19 @@ private fun Preview() {
         FlowRow {
             Text(
                 text = "titlepiece42",
-                style = Source.Typography.titlepiece42,
+                style = Source.Typography.Titlepiece42,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "titlepiece50",
-                style = Source.Typography.titlepiece50,
+                style = Source.Typography.Titlepiece50,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
 
             Text(
                 text = "titlepiece70",
-                style = Source.Typography.titlepiece70,
+                style = Source.Typography.Titlepiece70,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes naming and structuring to match that for Material icons and presets.

E.g. 
* `Source.typography.textArticle17` changes to `Source.Typography.TextArticle17`.
* `Source.palette.brand_400` changes to `Source.Palette.Brand_400`