### PR TITLE
Remove `_` from palette colour names

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.1.2"
+libraryVersion = "0.1.3"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "33"

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.gu.source.presets.palette.Brand_400
+import com.gu.source.presets.palette.Brand400
 import com.gu.source.presets.typography.TextArticle17
 
 class MainActivity : ComponentActivity() {
@@ -33,7 +33,7 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
         text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
         modifier = modifier,
         style = Source.Typography.TextArticle17,
-        color = Source.Palette.Brand_400,
+        color = Source.Palette.Brand400,
     )
 }
 

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -5,144 +5,144 @@ package com.gu.source.presets.palette
 import androidx.compose.ui.graphics.Color
 import com.gu.source.Source
 
-val Source.Palette.Brand_100: Color
+val Source.Palette.Brand100: Color
     get() = Color(color = 0xff001536)
-val Source.Palette.Brand_300: Color
+val Source.Palette.Brand300: Color
     get() = Color(color = 0xff041f4a)
-val Source.Palette.Brand_400: Color
+val Source.Palette.Brand400: Color
     get() = Color(color = 0xff052962)
-val Source.Palette.Brand_500: Color
+val Source.Palette.Brand500: Color
     get() = Color(color = 0xff007abc)
-val Source.Palette.Brand_600: Color
+val Source.Palette.Brand600: Color
     get() = Color(color = 0xff506991)
-val Source.Palette.Brand_800: Color
+val Source.Palette.Brand800: Color
     get() = Color(color = 0xffc1d8fc)
 
-val Source.Palette.BrandAlt_200: Color
+val Source.Palette.BrandAlt200: Color
     get() = Color(color = 0xfff3c100)
-val Source.Palette.BrandAlt_300: Color
+val Source.Palette.BrandAlt300: Color
     get() = Color(color = 0xffffd900)
-val Source.Palette.BrandAlt_400: Color
+val Source.Palette.BrandAlt400: Color
     get() = Color(color = 0xffffe500)
 
-val Source.Palette.Neutral_0: Color
+val Source.Palette.Neutral0: Color
     get() = Color(color = 0xff000000)
-val Source.Palette.Neutral_7: Color
+val Source.Palette.Neutral7: Color
     get() = Color(color = 0xff121212)
-val Source.Palette.Neutral_10: Color
+val Source.Palette.Neutral10: Color
     get() = Color(color = 0xff1a1a1a)
-val Source.Palette.Neutral_20: Color
+val Source.Palette.Neutral20: Color
     get() = Color(color = 0xff333333)
 
 /** Was previously #606060. Updated to improve contrast for accessibility. */
-val Source.Palette.Neutral_38: Color
+val Source.Palette.Neutral38: Color
     get() = Color(color = 0xff545454)
-val Source.Palette.Neutral_46: Color
+val Source.Palette.Neutral46: Color
     get() = Color(color = 0xff707070)
-val Source.Palette.Neutral_60: Color
+val Source.Palette.Neutral60: Color
     get() = Color(color = 0xff999999)
-val Source.Palette.Neutral_73: Color
+val Source.Palette.Neutral73: Color
     get() = Color(color = 0xffbababa)
-val Source.Palette.Neutral_86: Color
+val Source.Palette.Neutral86: Color
     get() = Color(color = 0xffdcdcdc)
-val Source.Palette.Neutral_93: Color
+val Source.Palette.Neutral93: Color
     get() = Color(color = 0xffededed)
-val Source.Palette.Neutral_97: Color
+val Source.Palette.Neutral97: Color
     get() = Color(color = 0xfff6f6f6)
-val Source.Palette.Neutral_100: Color
+val Source.Palette.Neutral100: Color
     get() = Color(color = 0xffffffff)
 
-val Source.Palette.Error_400: Color
+val Source.Palette.Error400: Color
     get() = Color(color = 0xffc70000)
-val Source.Palette.Error_500: Color
+val Source.Palette.Error500: Color
     get() = Color(color = 0xffFF9081)
-val Source.Palette.Success_400: Color
+val Source.Palette.Success400: Color
     get() = Color(color = 0xff22874d)
 
-val Source.Palette.News_100: Color
+val Source.Palette.News100: Color
     get() = Color(color = 0xff660505)
-val Source.Palette.News_200: Color
+val Source.Palette.News200: Color
     get() = Color(color = 0xff8b0000)
-val Source.Palette.News_300: Color
+val Source.Palette.News300: Color
     get() = Color(color = 0xffab0613)
-val Source.Palette.News_400: Color
+val Source.Palette.News400: Color
     get() = Color(color = 0xffc70000)
-val Source.Palette.News_500: Color
+val Source.Palette.News500: Color
     get() = Color(color = 0xffff5943)
-val Source.Palette.News_600: Color
+val Source.Palette.News600: Color
     get() = Color(color = 0xffffbac8)
-val Source.Palette.News_800: Color
+val Source.Palette.News800: Color
     get() = Color(color = 0xfffff4f2)
 
-val Source.Palette.Opinion_100: Color
+val Source.Palette.Opinion100: Color
     get() = Color(color = 0xff672005)
-val Source.Palette.Opinion_200: Color
+val Source.Palette.Opinion200: Color
     get() = Color(color = 0xff8d2700)
-val Source.Palette.Opinion_300: Color
+val Source.Palette.Opinion300: Color
     get() = Color(color = 0xffbd5318)
-val Source.Palette.Opinion_400: Color
+val Source.Palette.Opinion400: Color
     get() = Color(color = 0xffe05e00)
-val Source.Palette.Opinion_500: Color
+val Source.Palette.Opinion500: Color
     get() = Color(color = 0xffff7f0f)
-val Source.Palette.Opinion_600: Color
+val Source.Palette.Opinion600: Color
     get() = Color(color = 0xfff9b376)
-val Source.Palette.Opinion_800: Color
+val Source.Palette.Opinion800: Color
     get() = Color(color = 0xfffef9f5)
 
-val Source.Palette.Sport_100: Color
+val Source.Palette.Sport100: Color
     get() = Color(color = 0xff003c60)
-val Source.Palette.Sport_200: Color
+val Source.Palette.Sport200: Color
     get() = Color(color = 0xff004e7c)
-val Source.Palette.Sport_300: Color
+val Source.Palette.Sport300: Color
     get() = Color(color = 0xff005689)
-val Source.Palette.Sport_400: Color
+val Source.Palette.Sport400: Color
     get() = Color(color = 0xff0077B6)
-val Source.Palette.Sport_500: Color
+val Source.Palette.Sport500: Color
     get() = Color(color = 0xff00b2ff)
-val Source.Palette.Sport_600: Color
+val Source.Palette.Sport600: Color
     get() = Color(color = 0xff90dcff)
-val Source.Palette.Sport_800: Color
+val Source.Palette.Sport800: Color
     get() = Color(color = 0xfff1f8fc)
 
-val Source.Palette.Culture_100: Color
+val Source.Palette.Culture100: Color
     get() = Color(color = 0xff3e3323)
-val Source.Palette.Culture_200: Color
+val Source.Palette.Culture200: Color
     get() = Color(color = 0xff574835)
-val Source.Palette.Culture_300: Color
+val Source.Palette.Culture300: Color
     get() = Color(color = 0xff6b5840)
-val Source.Palette.Culture_400: Color
+val Source.Palette.Culture400: Color
     get() = Color(color = 0xffa1845c)
-val Source.Palette.Culture_500: Color
+val Source.Palette.Culture500: Color
     get() = Color(color = 0xffeacca0)
-val Source.Palette.Culture_600: Color
+val Source.Palette.Culture600: Color
     get() = Color(color = 0xffe7d4b9)
-val Source.Palette.Culture_800: Color
+val Source.Palette.Culture800: Color
     get() = Color(color = 0xfffbf6ef)
 
-val Source.Palette.Lifestyle_100: Color
+val Source.Palette.Lifestyle100: Color
     get() = Color(color = 0xff510043)
-val Source.Palette.Lifestyle_200: Color
+val Source.Palette.Lifestyle200: Color
     get() = Color(color = 0xff650054)
-val Source.Palette.Lifestyle_300: Color
+val Source.Palette.Lifestyle300: Color
     get() = Color(color = 0xff7d0068)
-val Source.Palette.Lifestyle_400: Color
+val Source.Palette.Lifestyle400: Color
     get() = Color(color = 0xffbb3b80)
-val Source.Palette.Lifestyle_500: Color
+val Source.Palette.Lifestyle500: Color
     get() = Color(color = 0xffffabdb)
-val Source.Palette.Lifestyle_600: Color
+val Source.Palette.Lifestyle600: Color
     get() = Color(color = 0xfffec8d3)
-val Source.Palette.Lifestyle_800: Color
+val Source.Palette.Lifestyle800: Color
     get() = Color(color = 0xfffeeef7)
 
-val Source.Palette.SpecialReport_100: Color
+val Source.Palette.SpecialReport100: Color
     get() = Color(color = 0xff222527)
-val Source.Palette.SpecialReport_200: Color
+val Source.Palette.SpecialReport200: Color
     get() = Color(color = 0xff303538)
-val Source.Palette.SpecialReport_300: Color
+val Source.Palette.SpecialReport300: Color
     get() = Color(color = 0xff3f464a)
-val Source.Palette.SpecialReport_400: Color
+val Source.Palette.SpecialReport400: Color
     get() = Color(color = 0xff63717a)
-val Source.Palette.SpecialReport_500: Color
+val Source.Palette.SpecialReport500: Color
     get() = Color(color = 0xffabc2c9)
-val Source.Palette.SpecialReport_800: Color
+val Source.Palette.SpecialReport800: Color
     get() = Color(color = 0xffeff1f2)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changing palette colour preset names to match the naming pattern for Typography presets, and Material colours.