### PR TITLE
Update palette colours

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.2.0"
+libraryVersion = "0.2.1"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "33"

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -187,10 +186,6 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                 )
             }
         }
-    }
-
-    LaunchedEffect(key1 = Unit) {
-        scaffoldState.bottomSheetState.expand()
     }
 }
 

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gu.source.components.buttons.SourceButton
@@ -15,10 +16,14 @@ import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
 import com.gu.source.icons.Check
 import com.gu.source.presets.palette.Brand400
+import com.gu.source.presets.palette.Neutral0
+import com.gu.source.presets.palette.Neutral100
 import com.gu.source.presets.palette.Neutral97
-import com.gu.source.presets.typography.TextArticle17
+import com.gu.source.presets.typography.HeadlineMedium20
+import com.gu.source.presets.typography.TextSansBold17
 import com.gu.source.theme.ReaderRevenueTheme
 import com.gu.source.utils.PhoneBothModePreviews
+import com.gu.source.utils.plus
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -45,112 +50,132 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
         scaffoldState = scaffoldState,
         sheetPeekHeight = 0.dp,
         sheetDragHandle = { Spacer(Modifier.height(4.dp)) },
+        containerColor = AppColour(
+            Source.Palette.Neutral100,
+            Source.Palette.Neutral0,
+        ).current,
         modifier = modifier,
     ) {
-        Surface(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
-            color = MaterialTheme.colorScheme.background,
+                .padding(it + PaddingValues(16.dp)),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(it),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
-                    modifier = Modifier,
-                    style = Source.Typography.TextArticle17,
-                    color = AppColour(
-                        light = Source.Palette.Brand400,
-                        dark = Source.Palette.Neutral97,
-                    ).current,
-                )
+            Text(
+                text = "Hello $name!",
+                modifier = Modifier,
+                style = Source.Typography.HeadlineMedium20,
+                color = AppColour(
+                    light = Source.Palette.Brand400,
+                    dark = Source.Palette.Neutral97,
+                ).current,
+            )
+            Text(
+                text = "We're Guardian, the world's leading liberal voice.",
+                modifier = Modifier,
+                style = Source.Typography.HeadlineMedium20,
+                color = AppColour(
+                    light = Source.Palette.Brand400,
+                    dark = Source.Palette.Neutral97,
+                ).current,
+            )
 
-                HorizontalDivider()
+            HorizontalDivider()
 
-                SourceButton(
-                    text = "Open palette",
-                    priority = SourceButton.Priority.TertiaryOnWhite,
-                    onClick = {
-                        coroutineScope.launch {
-                            scaffoldState.bottomSheetState.expand()
-                        }
-                    },
-                )
-
-                HorizontalDivider()
-
-                Row {
-                    SourceIconButton(
-                        icon = Source.Icons.Base.Check,
-                        priority = SourceButton.Priority.PrimaryOnWhite,
-                        contentDescription = null,
-                        onClick = {},
-                        size = SourceButton.Size.XSmall,
-                    )
-                    SourceButton(
-                        text = "Welcome",
-                        priority = SourceButton.Priority.SecondaryOnWhite,
-                        onClick = {},
-                        size = SourceButton.Size.XSmall,
-                    )
-                    SourceIconButton(
-                        icon = Source.Icons.Base.Check,
-                        priority = SourceButton.Priority.TertiaryOnWhite,
-                        contentDescription = null,
-                        onClick = {},
-                        size = SourceButton.Size.XSmall,
-                    )
-                }
-
-                ReaderRevenueTheme {
-                    Row(modifier = it) {
-                        SourceIconButton(
-                            icon = Source.Icons.Base.Check,
-                            priority = SourceButton.Priority.PrimaryOnWhite,
-                            contentDescription = null,
-                            onClick = {},
-                            size = SourceButton.Size.Small,
-                        )
-                        SourceButton(
-                            text = "to",
-                            priority = SourceButton.Priority.PrimaryOnWhite,
-                            onClick = {},
-                            size = SourceButton.Size.Small,
-                        )
-                        SourceIconButton(
-                            icon = Source.Icons.Base.Check,
-                            priority = SourceButton.Priority.TertiaryOnWhite,
-                            contentDescription = null,
-                            onClick = {},
-                            size = SourceButton.Size.Small,
-                        )
+            SourceButton(
+                text = "Open palette",
+                priority = SourceButton.Priority.TertiaryOnWhite,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                onClick = {
+                    coroutineScope.launch {
+                        scaffoldState.bottomSheetState.expand()
                     }
-                }
+                },
+            )
 
-                Row {
+            HorizontalDivider()
+
+            Text(text = "Button variants", style = Source.Typography.TextSansBold17)
+
+            Row {
+                SourceIconButton(
+                    icon = Source.Icons.Base.Check,
+                    priority = SourceButton.Priority.PrimaryOnWhite,
+                    contentDescription = null,
+                    onClick = {},
+                    size = SourceButton.Size.XSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                SourceButton(
+                    text = "Welcome",
+                    priority = SourceButton.Priority.SecondaryOnWhite,
+                    onClick = {},
+                    size = SourceButton.Size.XSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                SourceIconButton(
+                    icon = Source.Icons.Base.Check,
+                    priority = SourceButton.Priority.TertiaryOnWhite,
+                    contentDescription = null,
+                    onClick = {},
+                    size = SourceButton.Size.XSmall,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            ReaderRevenueTheme {
+                Row(modifier = it) {
                     SourceIconButton(
                         icon = Source.Icons.Base.Check,
                         priority = SourceButton.Priority.PrimaryOnWhite,
                         contentDescription = null,
                         onClick = {},
-                        size = SourceButton.Size.Medium,
+                        size = SourceButton.Size.Small,
+                        modifier = Modifier.weight(1f),
                     )
                     SourceButton(
-                        text = "Source",
-                        priority = SourceButton.Priority.SecondaryOnWhite,
+                        text = "to",
+                        priority = SourceButton.Priority.PrimaryOnWhite,
                         onClick = {},
-                        size = SourceButton.Size.Medium,
+                        size = SourceButton.Size.Small,
+                        modifier = Modifier.weight(1f),
                     )
                     SourceIconButton(
                         icon = Source.Icons.Base.Check,
                         priority = SourceButton.Priority.TertiaryOnWhite,
                         contentDescription = null,
                         onClick = {},
-                        size = SourceButton.Size.Medium,
+                        size = SourceButton.Size.Small,
+                        modifier = Modifier.weight(1f),
                     )
                 }
+            }
+
+            Row {
+                SourceIconButton(
+                    icon = Source.Icons.Base.Check,
+                    priority = SourceButton.Priority.PrimaryOnWhite,
+                    contentDescription = null,
+                    onClick = {},
+                    size = SourceButton.Size.Medium,
+                    modifier = Modifier.weight(1f),
+                )
+                SourceButton(
+                    text = "Source",
+                    priority = SourceButton.Priority.SecondaryOnWhite,
+                    onClick = {},
+                    size = SourceButton.Size.Medium,
+                    modifier = Modifier.weight(1f),
+                )
+                SourceIconButton(
+                    icon = Source.Icons.Base.Check,
+                    priority = SourceButton.Priority.TertiaryOnWhite,
+                    contentDescription = null,
+                    onClick = {},
+                    size = SourceButton.Size.Medium,
+                    modifier = Modifier.weight(1f),
+                )
             }
         }
     }

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -4,10 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gu.source.components.buttons.SourceButton
@@ -20,18 +19,14 @@ import com.gu.source.presets.palette.Neutral97
 import com.gu.source.presets.typography.TextArticle17
 import com.gu.source.theme.ReaderRevenueTheme
 import com.gu.source.utils.PhoneBothModePreviews
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppColourMode {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background,
-                ) {
-                    Greeting("Android")
-                }
+                Greeting("Android")
             }
         }
     }
@@ -39,92 +34,124 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Text(
-            text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
-            modifier = Modifier,
-            style = Source.Typography.TextArticle17,
-            color = AppColour(
-                light = Source.Palette.Brand400,
-                dark = Source.Palette.Neutral97,
-            ).current,
-        )
+    val coroutineScope = rememberCoroutineScope()
+    val sheetState = rememberStandardBottomSheetState(skipHiddenState = true)
+    val scaffoldState = rememberBottomSheetScaffoldState(
+        bottomSheetState = sheetState,
+    )
 
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row {
-            SourceIconButton(
-                icon = Source.Icons.Base.Check,
-                priority = SourceButton.Priority.PrimaryOnWhite,
-                contentDescription = null,
-                onClick = {},
-                size = SourceButton.Size.XSmall,
-            )
-            SourceButton(
-                text = "Welcome",
-                priority = SourceButton.Priority.SecondaryOnWhite,
-                onClick = {},
-                size = SourceButton.Size.XSmall,
-            )
-            SourceIconButton(
-                icon = Source.Icons.Base.Check,
-                priority = SourceButton.Priority.TertiaryOnWhite,
-                contentDescription = null,
-                onClick = {},
-                size = SourceButton.Size.XSmall,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        ReaderRevenueTheme {
-            Row(modifier = it) {
-                SourceIconButton(
-                    icon = Source.Icons.Base.Check,
-                    priority = SourceButton.Priority.PrimaryOnWhite,
-                    contentDescription = null,
-                    onClick = {},
-                    size = SourceButton.Size.Small,
+    BottomSheetScaffold(
+        sheetContent = { Palette() },
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = 0.dp,
+        sheetDragHandle = { Spacer(Modifier.height(4.dp)) },
+        modifier = modifier,
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Column(
+                modifier = Modifier.padding(it),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = "Hello $name!\nWe're the Guardian, the world's leading liberal voice.",
+                    modifier = Modifier,
+                    style = Source.Typography.TextArticle17,
+                    color = AppColour(
+                        light = Source.Palette.Brand400,
+                        dark = Source.Palette.Neutral97,
+                    ).current,
                 )
+
+                HorizontalDivider()
+
                 SourceButton(
-                    text = "to",
-                    priority = SourceButton.Priority.PrimaryOnWhite,
-                    onClick = {},
-                    size = SourceButton.Size.Small,
-                )
-                SourceIconButton(
-                    icon = Source.Icons.Base.Check,
+                    text = "Open palette",
                     priority = SourceButton.Priority.TertiaryOnWhite,
-                    contentDescription = null,
-                    onClick = {},
-                    size = SourceButton.Size.Small,
+                    onClick = {
+                        coroutineScope.launch {
+                            scaffoldState.bottomSheetState.expand()
+                        }
+                    },
                 )
+
+                HorizontalDivider()
+
+                Row {
+                    SourceIconButton(
+                        icon = Source.Icons.Base.Check,
+                        priority = SourceButton.Priority.PrimaryOnWhite,
+                        contentDescription = null,
+                        onClick = {},
+                        size = SourceButton.Size.XSmall,
+                    )
+                    SourceButton(
+                        text = "Welcome",
+                        priority = SourceButton.Priority.SecondaryOnWhite,
+                        onClick = {},
+                        size = SourceButton.Size.XSmall,
+                    )
+                    SourceIconButton(
+                        icon = Source.Icons.Base.Check,
+                        priority = SourceButton.Priority.TertiaryOnWhite,
+                        contentDescription = null,
+                        onClick = {},
+                        size = SourceButton.Size.XSmall,
+                    )
+                }
+
+                ReaderRevenueTheme {
+                    Row(modifier = it) {
+                        SourceIconButton(
+                            icon = Source.Icons.Base.Check,
+                            priority = SourceButton.Priority.PrimaryOnWhite,
+                            contentDescription = null,
+                            onClick = {},
+                            size = SourceButton.Size.Small,
+                        )
+                        SourceButton(
+                            text = "to",
+                            priority = SourceButton.Priority.PrimaryOnWhite,
+                            onClick = {},
+                            size = SourceButton.Size.Small,
+                        )
+                        SourceIconButton(
+                            icon = Source.Icons.Base.Check,
+                            priority = SourceButton.Priority.TertiaryOnWhite,
+                            contentDescription = null,
+                            onClick = {},
+                            size = SourceButton.Size.Small,
+                        )
+                    }
+                }
+
+                Row {
+                    SourceIconButton(
+                        icon = Source.Icons.Base.Check,
+                        priority = SourceButton.Priority.PrimaryOnWhite,
+                        contentDescription = null,
+                        onClick = {},
+                        size = SourceButton.Size.Medium,
+                    )
+                    SourceButton(
+                        text = "Source",
+                        priority = SourceButton.Priority.SecondaryOnWhite,
+                        onClick = {},
+                        size = SourceButton.Size.Medium,
+                    )
+                    SourceIconButton(
+                        icon = Source.Icons.Base.Check,
+                        priority = SourceButton.Priority.TertiaryOnWhite,
+                        contentDescription = null,
+                        onClick = {},
+                        size = SourceButton.Size.Medium,
+                    )
+                }
             }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row {
-            SourceIconButton(
-                icon = Source.Icons.Base.Check,
-                priority = SourceButton.Priority.PrimaryOnWhite,
-                contentDescription = null,
-                onClick = {},
-                size = SourceButton.Size.Medium,
-            )
-            SourceButton(
-                text = "Source",
-                priority = SourceButton.Priority.SecondaryOnWhite,
-                onClick = {},
-                size = SourceButton.Size.Medium,
-            )
-            SourceIconButton(
-                icon = Source.Icons.Base.Check,
-                priority = SourceButton.Priority.TertiaryOnWhite,
-                contentDescription = null,
-                onClick = {},
-                size = SourceButton.Size.Medium,
-            )
         }
     }
 }

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -3,9 +3,14 @@ package com.gu.source
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,9 +34,10 @@ import kotlinx.coroutines.launch
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             AppColourMode {
-                Greeting("Android")
+                Greeting("Android", modifier = it)
             }
         }
     }
@@ -40,21 +46,24 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun Greeting(name: String, modifier: Modifier = Modifier) {
     val coroutineScope = rememberCoroutineScope()
-    val sheetState = rememberStandardBottomSheetState(skipHiddenState = true)
-    val scaffoldState = rememberBottomSheetScaffoldState(
-        bottomSheetState = sheetState,
-    )
+    val scaffoldState = rememberBottomSheetScaffoldState()
 
     BottomSheetScaffold(
         sheetContent = { Palette() },
         scaffoldState = scaffoldState,
         sheetPeekHeight = 0.dp,
         sheetDragHandle = { Spacer(Modifier.height(4.dp)) },
+        sheetContainerColor = AppColour(
+            Source.Palette.Neutral100,
+            Source.Palette.Neutral0,
+        ).current,
+        sheetShadowElevation = 8.dp,
+        sheetTonalElevation = 8.dp,
         containerColor = AppColour(
             Source.Palette.Neutral100,
             Source.Palette.Neutral0,
         ).current,
-        modifier = modifier,
+        modifier = modifier.safeDrawingPadding(),
     ) {
         Column(
             modifier = Modifier
@@ -178,6 +187,10 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                 )
             }
         }
+    }
+
+    LaunchedEffect(key1 = Unit) {
+        scaffoldState.bottomSheetState.expand()
     }
 }
 

--- a/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
@@ -17,14 +17,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gu.source.daynight.AppColour
+import com.gu.source.daynight.AppColourMode
 import com.gu.source.presets.palette.*
 import com.gu.source.presets.typography.HeadlineBold20
 import com.gu.source.presets.typography.TextSans11
 import com.gu.source.presets.typography.TextSansBold14
 import com.gu.source.presets.typography.TextSansBold15
+import com.gu.source.utils.PhoneBothModePreviews
 
 private data class Colour(
     val name: String,
@@ -34,6 +35,8 @@ private data class Colour(
         .toHexString(HexFormat.UpperCase)
         .substring(2),
 )
+
+private const val ContentColourThreshold = 0.5f
 
 private val colours = mapOf(
     "Brand" to listOf(
@@ -134,14 +137,17 @@ private val colours = mapOf(
     ),
 )
 
-@Preview(device = "spec:width=1080px,height=8340px,dpi=440")
 @Composable
 internal fun Palette(modifier: Modifier = Modifier) {
     Surface(
-        modifier = modifier,
+        modifier = modifier.safeDrawingPadding(),
         color = AppColour(
             Source.Palette.Neutral100,
             Source.Palette.Neutral0,
+        ).current,
+        contentColor = AppColour(
+            Source.Palette.Neutral0,
+            Source.Palette.Neutral100,
         ).current,
     ) {
         LazyVerticalGrid(
@@ -168,8 +174,12 @@ internal fun Palette(modifier: Modifier = Modifier) {
                     }
                 }
                 items(colours[palette].orEmpty()) { colour ->
-                    val contentColour =
-                        if (colour.colour.luminance() > 0.5f) Color.Black else Color.White
+                    val contentColour = if (colour.colour.luminance() > ContentColourThreshold) {
+                        Color.Black
+                    } else {
+                        Color.White
+                    }
+
                     Box(
                         modifier = Modifier
                             .height(50.dp)
@@ -196,5 +206,13 @@ internal fun Palette(modifier: Modifier = Modifier) {
                 }
             }
         }
+    }
+}
+
+@PhoneBothModePreviews
+@Composable
+private fun Preview() {
+    AppColourMode {
+        Palette()
     }
 }

--- a/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
@@ -25,7 +26,6 @@ import com.gu.source.presets.typography.HeadlineBold20
 import com.gu.source.presets.typography.TextSans11
 import com.gu.source.presets.typography.TextSansBold14
 import com.gu.source.presets.typography.TextSansBold15
-import com.gu.source.utils.PhoneBothModePreviews
 
 private data class Colour(
     val name: String,
@@ -132,8 +132,22 @@ private val colours = mapOf(
         Colour("SpecialReport200", Source.Palette.SpecialReport200),
         Colour("SpecialReport300", Source.Palette.SpecialReport300),
         Colour("SpecialReport400", Source.Palette.SpecialReport400),
+        Colour("SpecialReport450", Source.Palette.SpecialReport450),
         Colour("SpecialReport500", Source.Palette.SpecialReport500),
+        Colour("SpecialReport700", Source.Palette.SpecialReport700),
         Colour("SpecialReport800", Source.Palette.SpecialReport800),
+    ),
+    "SpecialReportAlt" to listOf(
+        Colour("SpecialReportAlt100", Source.Palette.SpecialReportAlt100),
+        Colour("SpecialReportAlt200", Source.Palette.SpecialReportAlt200),
+        Colour("SpecialReportAlt300", Source.Palette.SpecialReportAlt300),
+        Colour("SpecialReportAlt700", Source.Palette.SpecialReportAlt700),
+        Colour("SpecialReportAlt800", Source.Palette.SpecialReportAlt800),
+    ),
+    "Labs" to listOf(
+        Colour("Labs200", Source.Palette.Labs200),
+        Colour("Labs300", Source.Palette.Labs300),
+        Colour("Labs400", Source.Palette.Labs400),
     ),
 )
 
@@ -209,7 +223,7 @@ internal fun Palette(modifier: Modifier = Modifier) {
     }
 }
 
-@PhoneBothModePreviews
+@Preview(device = "spec:width=1080px,height=8340px,dpi=440")
 @Composable
 private fun Preview() {
     AppColourMode {

--- a/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
@@ -1,0 +1,171 @@
+package com.gu.source
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gu.source.presets.palette.*
+import com.gu.source.presets.typography.HeadlineBold20
+import com.gu.source.presets.typography.TextSans14
+import com.gu.source.presets.typography.TextSansBold14
+
+private data class Colour(
+    val name: String,
+    val colour: Color,
+)
+
+private val colours = mapOf(
+    "Brand" to listOf(
+        Colour("Brand100", Source.Palette.Brand100),
+        Colour("Brand300", Source.Palette.Brand300),
+        Colour("Brand400", Source.Palette.Brand400),
+        Colour("Brand500", Source.Palette.Brand500),
+        Colour("Brand600", Source.Palette.Brand600),
+        Colour("Brand800", Source.Palette.Brand800),
+    ),
+    "BrandAlt" to listOf(
+        Colour("BrandAlt200", Source.Palette.BrandAlt200),
+        Colour("BrandAlt300", Source.Palette.BrandAlt300),
+        Colour("BrandAlt400", Source.Palette.BrandAlt400),
+    ),
+    "Neutral" to listOf(
+        Colour("Neutral0", Source.Palette.Neutral0),
+        Colour("Neutral7", Source.Palette.Neutral7),
+        Colour("Neutral10", Source.Palette.Neutral10),
+        Colour("Neutral20", Source.Palette.Neutral20),
+        Colour("Neutral38", Source.Palette.Neutral38),
+        Colour("Neutral46", Source.Palette.Neutral46),
+        Colour("Neutral60", Source.Palette.Neutral60),
+        Colour("Neutral73", Source.Palette.Neutral73),
+        Colour("Neutral86", Source.Palette.Neutral86),
+        Colour("Neutral93", Source.Palette.Neutral93),
+        Colour("Neutral97", Source.Palette.Neutral97),
+        Colour("Neutral100", Source.Palette.Neutral100),
+    ),
+    "Error" to listOf(
+        Colour("Error400", Source.Palette.Error400),
+        Colour("Error500", Source.Palette.Error500),
+    ),
+    "Success" to listOf(
+        Colour("Success300", Source.Palette.Success300),
+        Colour("Success400", Source.Palette.Success400),
+        Colour("Success500", Source.Palette.Success500),
+    ),
+    "News" to listOf(
+        Colour("News100", Source.Palette.News100),
+        Colour("News200", Source.Palette.News200),
+        Colour("News300", Source.Palette.News300),
+        Colour("News400", Source.Palette.News400),
+        Colour("News500", Source.Palette.News500),
+        Colour("News550", Source.Palette.News550),
+        Colour("News600", Source.Palette.News600),
+        Colour("News800", Source.Palette.News800),
+    ),
+    "Opinion" to listOf(
+        Colour("Opinion100", Source.Palette.Opinion100),
+        Colour("Opinion200", Source.Palette.Opinion200),
+        Colour("Opinion300", Source.Palette.Opinion300),
+        Colour("Opinion400", Source.Palette.Opinion400),
+        Colour("Opinion450", Source.Palette.Opinion450),
+        Colour("Opinion500", Source.Palette.Opinion500),
+        Colour("Opinion550", Source.Palette.Opinion550),
+        Colour("Opinion600", Source.Palette.Opinion600),
+        Colour("Opinion800", Source.Palette.Opinion800),
+    ),
+    "Sport" to listOf(
+        Colour("Sport100", Source.Palette.Sport100),
+        Colour("Sport200", Source.Palette.Sport200),
+        Colour("Sport300", Source.Palette.Sport300),
+        Colour("Sport400", Source.Palette.Sport400),
+        Colour("Sport500", Source.Palette.Sport500),
+        Colour("Sport600", Source.Palette.Sport600),
+        Colour("Sport800", Source.Palette.Sport800),
+    ),
+    "Culture" to listOf(
+        Colour("Culture50", Source.Palette.Culture50),
+        Colour("Culture100", Source.Palette.Culture100),
+        Colour("Culture200", Source.Palette.Culture200),
+        Colour("Culture300", Source.Palette.Culture300),
+        Colour("Culture400", Source.Palette.Culture400),
+        Colour("Culture450", Source.Palette.Culture450),
+        Colour("Culture500", Source.Palette.Culture500),
+        Colour("Culture600", Source.Palette.Culture600),
+        Colour("Culture700", Source.Palette.Culture700),
+        Colour("Culture800", Source.Palette.Culture800),
+    ),
+    "Lifestyle" to listOf(
+        Colour("Lifestyle100", Source.Palette.Lifestyle100),
+        Colour("Lifestyle200", Source.Palette.Lifestyle200),
+        Colour("Lifestyle300", Source.Palette.Lifestyle300),
+        Colour("Lifestyle400", Source.Palette.Lifestyle400),
+        Colour("Lifestyle450", Source.Palette.Lifestyle450),
+        Colour("Lifestyle500", Source.Palette.Lifestyle500),
+        Colour("Lifestyle600", Source.Palette.Lifestyle600),
+        Colour("Lifestyle800", Source.Palette.Lifestyle800),
+    ),
+    "SpecialReport" to listOf(
+        Colour("SpecialReport100", Source.Palette.SpecialReport100),
+        Colour("SpecialReport200", Source.Palette.SpecialReport200),
+        Colour("SpecialReport300", Source.Palette.SpecialReport300),
+        Colour("SpecialReport400", Source.Palette.SpecialReport400),
+        Colour("SpecialReport500", Source.Palette.SpecialReport500),
+        Colour("SpecialReport800", Source.Palette.SpecialReport800),
+    ),
+)
+
+@Preview
+@Composable
+internal fun Palette(modifier: Modifier = Modifier) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        contentPadding = PaddingValues(vertical = 8.dp),
+        modifier = modifier,
+    ) {
+        item {
+            Text(
+                text = "Palette",
+                style = Source.Typography.HeadlineBold20,
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+        colours.keys.forEachIndexed { paletteIndex, palette ->
+            item(span = { GridItemSpan(2) }) {
+                Column {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    HorizontalDivider()
+                    Text(
+                        text = palette,
+                        style = Source.Typography.TextSansBold14,
+                        modifier = Modifier.padding(8.dp),
+                    )
+                }
+            }
+            items(colours[palette].orEmpty()) { colour ->
+                Box(
+                    modifier = Modifier
+                        .height(50.dp)
+                        .fillMaxWidth()
+                        .background(colour.colour),
+                ) {
+                    Text(
+                        text = colour.name,
+                        modifier = Modifier.align(Alignment.Center),
+                        style = Source.Typography.TextSans14,
+                        color = if (colour.colour.luminance() > 0.5f) Color.Black else Color.White,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/PalettePreview.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package com.gu.source
 
 import androidx.compose.foundation.background
@@ -7,22 +9,30 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.gu.source.daynight.AppColour
 import com.gu.source.presets.palette.*
 import com.gu.source.presets.typography.HeadlineBold20
-import com.gu.source.presets.typography.TextSans14
+import com.gu.source.presets.typography.TextSans11
 import com.gu.source.presets.typography.TextSansBold14
+import com.gu.source.presets.typography.TextSansBold15
 
 private data class Colour(
     val name: String,
     val colour: Color,
+    val colourValue: String = colour
+        .toArgb()
+        .toHexString(HexFormat.UpperCase)
+        .substring(2),
 )
 
 private val colours = mapOf(
@@ -124,46 +134,65 @@ private val colours = mapOf(
     ),
 )
 
-@Preview
+@Preview(device = "spec:width=1080px,height=8340px,dpi=440")
 @Composable
 internal fun Palette(modifier: Modifier = Modifier) {
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(vertical = 8.dp),
+    Surface(
         modifier = modifier,
+        color = AppColour(
+            Source.Palette.Neutral100,
+            Source.Palette.Neutral0,
+        ).current,
     ) {
-        item {
-            Text(
-                text = "Palette",
-                style = Source.Typography.HeadlineBold20,
-                modifier = Modifier.padding(8.dp),
-            )
-        }
-        colours.keys.forEachIndexed { paletteIndex, palette ->
-            item(span = { GridItemSpan(2) }) {
-                Column {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    HorizontalDivider()
-                    Text(
-                        text = palette,
-                        style = Source.Typography.TextSansBold14,
-                        modifier = Modifier.padding(8.dp),
-                    )
-                }
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(vertical = 8.dp),
+        ) {
+            item {
+                Text(
+                    text = "Palette",
+                    style = Source.Typography.HeadlineBold20,
+                    modifier = Modifier.padding(8.dp),
+                )
             }
-            items(colours[palette].orEmpty()) { colour ->
-                Box(
-                    modifier = Modifier
-                        .height(50.dp)
-                        .fillMaxWidth()
-                        .background(colour.colour),
-                ) {
-                    Text(
-                        text = colour.name,
-                        modifier = Modifier.align(Alignment.Center),
-                        style = Source.Typography.TextSans14,
-                        color = if (colour.colour.luminance() > 0.5f) Color.Black else Color.White,
-                    )
+            colours.keys.forEachIndexed { paletteIndex, palette ->
+                item(span = { GridItemSpan(2) }) {
+                    Column {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        HorizontalDivider()
+                        Text(
+                            text = palette,
+                            style = Source.Typography.TextSansBold14,
+                            modifier = Modifier.padding(8.dp),
+                        )
+                    }
+                }
+                items(colours[palette].orEmpty()) { colour ->
+                    val contentColour =
+                        if (colour.colour.luminance() > 0.5f) Color.Black else Color.White
+                    Box(
+                        modifier = Modifier
+                            .height(50.dp)
+                            .fillMaxWidth()
+                            .background(colour.colour),
+                    ) {
+                        Text(
+                            text = colour.name,
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .padding(top = 8.dp),
+                            style = Source.Typography.TextSansBold15,
+                            color = contentColour,
+                        )
+                        Text(
+                            text = "#${colour.colourValue}",
+                            color = contentColour,
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 8.dp),
+                            style = Source.Typography.TextSans11,
+                        )
+                    }
                 }
             }
         }

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -84,6 +84,8 @@ val Source.Palette.Opinion100: Color
     get() = Color(color = 0xff672005)
 val Source.Palette.Opinion200: Color
     get() = Color(color = 0xff8d2700)
+
+@Deprecated("Use Opinion400 instead", ReplaceWith("Opinion400"))
 val Source.Palette.Opinion300: Color
     get() = Color(color = 0xffbd5318)
 val Source.Palette.Opinion400: Color

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -12,7 +12,7 @@ val Source.Palette.Brand300: Color
 val Source.Palette.Brand400: Color
     get() = Color(color = 0xff052962)
 val Source.Palette.Brand500: Color
-    get() = Color(color = 0xff007abc)
+    get() = Color(color = 0xff0077b6)
 val Source.Palette.Brand600: Color
     get() = Color(color = 0xff506991)
 val Source.Palette.Brand800: Color
@@ -55,9 +55,13 @@ val Source.Palette.Neutral100: Color
 val Source.Palette.Error400: Color
     get() = Color(color = 0xffc70000)
 val Source.Palette.Error500: Color
-    get() = Color(color = 0xffFF9081)
+    get() = Color(color = 0xffff9081)
+val Source.Palette.Success300: Color
+    get() = Color(color = 0xff185e36)
 val Source.Palette.Success400: Color
     get() = Color(color = 0xff22874d)
+val Source.Palette.Success500: Color
+    get() = Color(color = 0xff58d08b)
 
 val Source.Palette.News100: Color
     get() = Color(color = 0xff660505)
@@ -69,6 +73,8 @@ val Source.Palette.News400: Color
     get() = Color(color = 0xffc70000)
 val Source.Palette.News500: Color
     get() = Color(color = 0xffff5943)
+val Source.Palette.News550: Color
+    get() = Color(color = 0xffff9081)
 val Source.Palette.News600: Color
     get() = Color(color = 0xffffbac8)
 val Source.Palette.News800: Color
@@ -81,9 +87,13 @@ val Source.Palette.Opinion200: Color
 val Source.Palette.Opinion300: Color
     get() = Color(color = 0xffbd5318)
 val Source.Palette.Opinion400: Color
+    get() = Color(color = 0xffc74600)
+val Source.Palette.Opinion450: Color
     get() = Color(color = 0xffe05e00)
 val Source.Palette.Opinion500: Color
     get() = Color(color = 0xffff7f0f)
+val Source.Palette.Opinion550: Color
+    get() = Color(color = 0xffff9941)
 val Source.Palette.Opinion600: Color
     get() = Color(color = 0xfff9b376)
 val Source.Palette.Opinion800: Color
@@ -96,7 +106,7 @@ val Source.Palette.Sport200: Color
 val Source.Palette.Sport300: Color
     get() = Color(color = 0xff005689)
 val Source.Palette.Sport400: Color
-    get() = Color(color = 0xff0077B6)
+    get() = Color(color = 0xff0077b6)
 val Source.Palette.Sport500: Color
     get() = Color(color = 0xff00b2ff)
 val Source.Palette.Sport600: Color
@@ -104,6 +114,8 @@ val Source.Palette.Sport600: Color
 val Source.Palette.Sport800: Color
     get() = Color(color = 0xfff1f8fc)
 
+val Source.Palette.Culture50: Color
+    get() = Color(color = 0xff2b2625)
 val Source.Palette.Culture100: Color
     get() = Color(color = 0xff3e3323)
 val Source.Palette.Culture200: Color
@@ -111,11 +123,15 @@ val Source.Palette.Culture200: Color
 val Source.Palette.Culture300: Color
     get() = Color(color = 0xff6b5840)
 val Source.Palette.Culture400: Color
+    get() = Color(color = 0xff866d50)
+val Source.Palette.Culture450: Color
     get() = Color(color = 0xffa1845c)
 val Source.Palette.Culture500: Color
     get() = Color(color = 0xffeacca0)
 val Source.Palette.Culture600: Color
     get() = Color(color = 0xffe7d4b9)
+val Source.Palette.Culture700: Color
+    get() = Color(color = 0xffefe8dd)
 val Source.Palette.Culture800: Color
     get() = Color(color = 0xfffbf6ef)
 
@@ -127,6 +143,8 @@ val Source.Palette.Lifestyle300: Color
     get() = Color(color = 0xff7d0068)
 val Source.Palette.Lifestyle400: Color
     get() = Color(color = 0xffbb3b80)
+val Source.Palette.Lifestyle450: Color
+    get() = Color(color = 0xfff37abc)
 val Source.Palette.Lifestyle500: Color
     get() = Color(color = 0xffffabdb)
 val Source.Palette.Lifestyle600: Color
@@ -141,7 +159,7 @@ val Source.Palette.SpecialReport200: Color
 val Source.Palette.SpecialReport300: Color
     get() = Color(color = 0xff3f464a)
 val Source.Palette.SpecialReport400: Color
-    get() = Color(color = 0xff595C5F)
+    get() = Color(color = 0xff595c5f)
 val Source.Palette.SpecialReport500: Color
     get() = Color(color = 0xffabc2c9)
 val Source.Palette.SpecialReport800: Color

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -56,6 +56,7 @@ val Source.Palette.Error400: Color
     get() = Color(color = 0xffc70000)
 val Source.Palette.Error500: Color
     get() = Color(color = 0xffff9081)
+
 val Source.Palette.Success300: Color
     get() = Color(color = 0xff185e36)
 val Source.Palette.Success400: Color

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -5,6 +5,9 @@ package com.gu.source.presets.palette
 import androidx.compose.ui.graphics.Color
 import com.gu.source.Source
 
+// Dev note: When adding new colours here, please also add them to `PalettePreview.kt` in the
+// sample module.
+
 val Source.Palette.Brand100: Color
     get() = Color(color = 0xff001536)
 val Source.Palette.Brand300: Color

--- a/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
+++ b/android/source/src/main/kotlin/com/gu/source/presets/palette/Palette.kt
@@ -166,7 +166,29 @@ val Source.Palette.SpecialReport300: Color
     get() = Color(color = 0xff3f464a)
 val Source.Palette.SpecialReport400: Color
     get() = Color(color = 0xff595c5f)
+val Source.Palette.SpecialReport450: Color
+    get() = Color(color = 0xff9da0a2)
 val Source.Palette.SpecialReport500: Color
     get() = Color(color = 0xffabc2c9)
+val Source.Palette.SpecialReport700: Color
+    get() = Color(color = 0xffe4e5e8)
 val Source.Palette.SpecialReport800: Color
     get() = Color(color = 0xffeff1f2)
+
+val Source.Palette.SpecialReportAlt100: Color
+    get() = Color(color = 0xff2b2b2a)
+val Source.Palette.SpecialReportAlt200: Color
+    get() = Color(color = 0xffb9300a)
+val Source.Palette.SpecialReportAlt300: Color
+    get() = Color(color = 0xffff663d)
+val Source.Palette.SpecialReportAlt700: Color
+    get() = Color(color = 0xffebe6e1)
+val Source.Palette.SpecialReportAlt800: Color
+    get() = Color(color = 0xfff5f0eb)
+
+val Source.Palette.Labs200: Color
+    get() = Color(color = 0xff0c7a73)
+val Source.Palette.Labs300: Color
+    get() = Color(color = 0xff65a897)
+val Source.Palette.Labs400: Color
+    get() = Color(color = 0xff69d1ca)

--- a/android/source/src/main/res/values/palette.xml
+++ b/android/source/src/main/res/values/palette.xml
@@ -5,98 +5,108 @@
     <!-- endregion -->
     
     <!-- region Core brand extended colours -->
-    <color name="brand_100">#001536</color> <!-- guardian_brand_darkest -->
-    <color name="brand_300">#041f4a</color> <!-- guardian_brand_dark -->
-    <color name="brand_500">#007abc</color> <!-- sport_main_new -->
-    <color name="brand_600">#506991</color> <!-- guardian_brand_pastel -->
+    <color name="brand_100">#001536</color>
+    <color name="brand_300">#041f4a</color>
+    <color name="brand_500">#0077b6</color>
+    <color name="brand_600">#506991</color>
     <color name="brand_800">#c1d8fc</color>
     <!-- endregion -->
     
     <!-- region Alternative brand colours -->
-    <color name="brandAlt_400">#ffe500</color> <!-- highlight_main -->
-    <color name="brandAlt_200">#f3c100</color> <!-- highlight_extradark -->
+    <color name="brandAlt_200">#f3c100</color>
+    <color name="brandAlt_400">#ffe500</color>
     <color name="brandAlt_300">#ffd900</color>
     <!-- endregion -->
+    
     <!-- region Neutral -->
-    <color name="neutral_0">#000000</color> <!-- brightness_0 -->
-    <color name="neutral_7">#121212</color> <!-- brightness_7 -->
-    <color name="neutral_10">#1a1a1a</color> <!-- brightness_10 -->
-    <color name="neutral_20">#333333</color> <!-- brightness_20 -->
-    <color name="neutral_38">#606060</color>
-    <color name="neutral_46">#707070</color> <!-- brightness_46 -->
-    <color name="neutral_60">#999999</color> <!-- brightness_60 -->
-    <color name="neutral_86">#dcdcdc</color> <!-- brightness_86 -->
-    <color name="neutral_93">#ededed</color> <!-- brightness_93 -->
-    <color name="neutral_97">#f6f6f6</color> <!-- brightness_97 -->
-    <color name="neutral_100">#ffffff</color> <!-- brightness_100 -->
+    <color name="neutral_0">#000000</color>
+    <color name="neutral_7">#121212</color>
+    <color name="neutral_10">#1a1a1a</color>
+    <color name="neutral_20">#333333</color>
+    <color name="neutral_38">#545454</color>
+    <color name="neutral_46">#707070</color>
+    <color name="neutral_60">#999999</color>
+    <color name="neutral_73">#bababa</color>
+    <color name="neutral_86">#dcdcdc</color>
+    <color name="neutral_93">#ededed</color>
+    <color name="neutral_97">#f6f6f6</color>
+    <color name="neutral_100">#ffffff</color>
     <!-- endregion -->
     
-    <!-- region Messaging -->
-    <!-- Error -->
+    <!-- region Error -->
     <color name="error_400">#c70000</color>
     <color name="error_500">#ff9081</color>
-    <!-- Success -->
-    <color name="success_400">#22874d</color>
     <!-- endregion -->
     
-    <!-- region Pillar colours -->
+    <!-- region Success -->
+    <color name="success_300">#185e36</color>
+    <color name="success_400">#22874d</color>
+    <color name="success_500">#58d08b</color>
+    <!-- endregion -->
+    
     <!-- region News -->
-    <color name="news_400">#c70000</color> <!-- news_main -->
-    <color name="news_100">#660505</color> <!-- news_darkest -->
-    <color name="news_200">#8b0000</color> <!-- news_extradark -->
-    <color name="news_300">#ab0613</color> <!-- news_dark -->
+    <color name="news_100">#660505</color>
+    <color name="news_200">#8b0000</color>
+    <color name="news_300">#ab0613</color>
+    <color name="news_400">#c70000</color>
     <color name="news_500">#ff5943</color>
+    <color name="news_550">#ff9081</color>
     <color name="news_600">#ffbac8</color>
-    <color name="news_800">#fff4f2</color> <!-- news_faded -->
+    <color name="news_800">#fff4f2</color>
     <!-- endregion -->
     
     <!-- region Opinion -->
-    <color name="opinion_100">#672005</color> <!-- opinion_darkest -->
-    <color name="opinion_200">#8d2700</color> <!-- opinion_extradark -->
-    <color name="opinion_300">#bd5318</color> <!-- opinion_dark -->
-    <color name="opinion_400">#e05e00</color> <!-- opinion_main -->
-    <color name="opinion_500">#ff7f0f</color> <!-- opinion_bright -->
-    <color name="opinion_600">#f9b376</color> <!-- opinion_pastel -->
-    <color name="opinion_800">#fef9f5</color> <!-- opinion_faded -->
+    <color name="opinion_100">#672005</color>
+    <color name="opinion_200">#8d2700</color>
+    <color name="opinion_300">#bd5318</color>
+    <color name="opinion_400">#c74600</color>
+    <color name="opinion_450">#e05e00</color>
+    <color name="opinion_500">#ff7f0f</color>
+    <color name="opinion_550">#ff9941</color>
+    <color name="opinion_600">#f9b376</color>
+    <color name="opinion_800">#fef9f5</color>
     <!-- endregion -->
     
     <!-- region Sport -->
-    <color name="sport_100">#003c60</color> <!-- sport_darkest -->
-    <color name="sport_200">#004e7c</color> <!-- sport_extradark -->
-    <color name="sport_300">#005689</color> <!-- sport_dark -->
-    <color name="sport_400">#0077B6</color> <!-- sport_main_new -->
-    <color name="sport_500">#00b2ff</color> <!-- sport_bright -->
-    <color name="sport_600">#90dcff</color> <!-- sport_pastel -->
-    <color name="sport_800">#f1f8fc</color> <!-- sport_faded -->
+    <color name="sport_100">#003c60</color>
+    <color name="sport_200">#004e7c</color>
+    <color name="sport_300">#005689</color>
+    <color name="sport_400">#0077b6</color>
+    <color name="sport_500">#00b2ff</color>
+    <color name="sport_600">#90dcff</color>
+    <color name="sport_800">#f1f8fc</color>
     <!-- endregion -->
     
     <!-- region Culture -->
-    <color name="culture_100">#3e3323</color> <!-- culture_darkest -->
-    <color name="culture_200">#574835</color> <!-- culture_extradark -->
-    <color name="culture_300">#6b5840</color> <!-- culture_dark -->
-    <color name="culture_400">#a1845c</color> <!-- culture_main -->
-    <color name="culture_500">#eacca0</color> <!-- culture_bright -->
-    <color name="culture_600">#e7d4b9</color> <!-- culture_pastel -->
-    <color name="culture_800">#fbf6ef</color> <!-- culture_faded -->
+    <color name="culture_50">#2b2625</color>
+    <color name="culture_100">#3e3323</color>
+    <color name="culture_200">#574835</color>
+    <color name="culture_300">#6b5840</color>
+    <color name="culture_400">#866d50</color>
+    <color name="culture_450">#a1845c</color>
+    <color name="culture_500">#eacca0</color>
+    <color name="culture_600">#e7d4b9</color>
+    <color name="culture_700">#efe8dd</color>
+    <color name="culture_800">#fbf6ef</color>
     <!-- endregion -->
     
     <!-- region Lifestyle -->
-    <color name="lifestyle_100">#510043</color> <!-- lifestyle_darkest -->
-    <color name="lifestyle_200">#650054</color> <!-- lifestyle_extradark -->
-    <color name="lifestyle_300">#7d0068</color> <!-- lifestyle_dark -->
-    <color name="lifestyle_400">#bb3b80</color> <!-- lifestyle_main -->
-    <color name="lifestyle_500">#ffabdb</color> <!-- lifestyle_bright -->
-    <color name="lifestyle_600">#fec8d3</color> <!-- lifestyle_pastel -->
-    <color name="lifestyle_800">#feeef7</color> <!-- lifestyle_faded -->
-    <!-- endregion -->
+    <color name="lifestyle_100">#510043</color>
+    <color name="lifestyle_200">#650054</color>
+    <color name="lifestyle_300">#7d0068</color>
+    <color name="lifestyle_400">#bb3b80</color>
+    <color name="lifestyle_450">#f37abc</color>
+    <color name="lifestyle_500">#ffabdb</color>
+    <color name="lifestyle_600">#fec8d3</color>
+    <color name="lifestyle_800">#feeef7</color>
     <!-- endregion -->
     
     <!-- region Special Report -->
-    <color name="specialReport_100">#222527</color> <!-- special_report_darkest -->
-    <color name="specialReport_200">#303538</color> <!-- special_report_extradark -->
-    <color name="specialReport_300">#3f464a</color> <!-- special_report_dark -->
-    <color name="specialReport_400">#63717a</color> <!-- special_report_main -->
-    <color name="specialReport_500">#abc2c9</color> <!-- special_report_bright -->
-    <color name="specialReport_800">#eff1f2</color> <!-- special_report_faded -->
+    <color name="specialReport_100">#222527</color>
+    <color name="specialReport_200">#303538</color>
+    <color name="specialReport_300">#3f464a</color>
+    <color name="specialReport_400">#595c5f</color>
+    <color name="specialReport_500">#abc2c9</color>
+    <color name="specialReport_800">#eff1f2</color>
     <!-- endregion -->
 </resources>

--- a/android/source/src/main/res/values/palette.xml
+++ b/android/source/src/main/res/values/palette.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- region Core brand colour -->
+    <color name="brand_400">#052962</color> <!-- guardian_brand_main -->
+    <!-- endregion -->
+    
+    <!-- region Core brand extended colours -->
+    <color name="brand_100">#001536</color> <!-- guardian_brand_darkest -->
+    <color name="brand_300">#041f4a</color> <!-- guardian_brand_dark -->
+    <color name="brand_500">#007abc</color> <!-- sport_main_new -->
+    <color name="brand_600">#506991</color> <!-- guardian_brand_pastel -->
+    <color name="brand_800">#c1d8fc</color>
+    <!-- endregion -->
+    
+    <!-- region Alternative brand colours -->
+    <color name="brandAlt_400">#ffe500</color> <!-- highlight_main -->
+    <color name="brandAlt_200">#f3c100</color> <!-- highlight_extradark -->
+    <color name="brandAlt_300">#ffd900</color>
+    <!-- endregion -->
+    <!-- region Neutral -->
+    <color name="neutral_0">#000000</color> <!-- brightness_0 -->
+    <color name="neutral_7">#121212</color> <!-- brightness_7 -->
+    <color name="neutral_10">#1a1a1a</color> <!-- brightness_10 -->
+    <color name="neutral_20">#333333</color> <!-- brightness_20 -->
+    <color name="neutral_38">#606060</color>
+    <color name="neutral_46">#707070</color> <!-- brightness_46 -->
+    <color name="neutral_60">#999999</color> <!-- brightness_60 -->
+    <color name="neutral_86">#dcdcdc</color> <!-- brightness_86 -->
+    <color name="neutral_93">#ededed</color> <!-- brightness_93 -->
+    <color name="neutral_97">#f6f6f6</color> <!-- brightness_97 -->
+    <color name="neutral_100">#ffffff</color> <!-- brightness_100 -->
+    <!-- endregion -->
+    
+    <!-- region Messaging -->
+    <!-- Error -->
+    <color name="error_400">#c70000</color>
+    <color name="error_500">#ff9081</color>
+    <!-- Success -->
+    <color name="success_400">#22874d</color>
+    <!-- endregion -->
+    
+    <!-- region Pillar colours -->
+    <!-- region News -->
+    <color name="news_400">#c70000</color> <!-- news_main -->
+    <color name="news_100">#660505</color> <!-- news_darkest -->
+    <color name="news_200">#8b0000</color> <!-- news_extradark -->
+    <color name="news_300">#ab0613</color> <!-- news_dark -->
+    <color name="news_500">#ff5943</color>
+    <color name="news_600">#ffbac8</color>
+    <color name="news_800">#fff4f2</color> <!-- news_faded -->
+    <!-- endregion -->
+    
+    <!-- region Opinion -->
+    <color name="opinion_100">#672005</color> <!-- opinion_darkest -->
+    <color name="opinion_200">#8d2700</color> <!-- opinion_extradark -->
+    <color name="opinion_300">#bd5318</color> <!-- opinion_dark -->
+    <color name="opinion_400">#e05e00</color> <!-- opinion_main -->
+    <color name="opinion_500">#ff7f0f</color> <!-- opinion_bright -->
+    <color name="opinion_600">#f9b376</color> <!-- opinion_pastel -->
+    <color name="opinion_800">#fef9f5</color> <!-- opinion_faded -->
+    <!-- endregion -->
+    
+    <!-- region Sport -->
+    <color name="sport_100">#003c60</color> <!-- sport_darkest -->
+    <color name="sport_200">#004e7c</color> <!-- sport_extradark -->
+    <color name="sport_300">#005689</color> <!-- sport_dark -->
+    <color name="sport_400">#0077B6</color> <!-- sport_main_new -->
+    <color name="sport_500">#00b2ff</color> <!-- sport_bright -->
+    <color name="sport_600">#90dcff</color> <!-- sport_pastel -->
+    <color name="sport_800">#f1f8fc</color> <!-- sport_faded -->
+    <!-- endregion -->
+    
+    <!-- region Culture -->
+    <color name="culture_100">#3e3323</color> <!-- culture_darkest -->
+    <color name="culture_200">#574835</color> <!-- culture_extradark -->
+    <color name="culture_300">#6b5840</color> <!-- culture_dark -->
+    <color name="culture_400">#a1845c</color> <!-- culture_main -->
+    <color name="culture_500">#eacca0</color> <!-- culture_bright -->
+    <color name="culture_600">#e7d4b9</color> <!-- culture_pastel -->
+    <color name="culture_800">#fbf6ef</color> <!-- culture_faded -->
+    <!-- endregion -->
+    
+    <!-- region Lifestyle -->
+    <color name="lifestyle_100">#510043</color> <!-- lifestyle_darkest -->
+    <color name="lifestyle_200">#650054</color> <!-- lifestyle_extradark -->
+    <color name="lifestyle_300">#7d0068</color> <!-- lifestyle_dark -->
+    <color name="lifestyle_400">#bb3b80</color> <!-- lifestyle_main -->
+    <color name="lifestyle_500">#ffabdb</color> <!-- lifestyle_bright -->
+    <color name="lifestyle_600">#fec8d3</color> <!-- lifestyle_pastel -->
+    <color name="lifestyle_800">#feeef7</color> <!-- lifestyle_faded -->
+    <!-- endregion -->
+    <!-- endregion -->
+    
+    <!-- region Special Report -->
+    <color name="specialReport_100">#222527</color> <!-- special_report_darkest -->
+    <color name="specialReport_200">#303538</color> <!-- special_report_extradark -->
+    <color name="specialReport_300">#3f464a</color> <!-- special_report_dark -->
+    <color name="specialReport_400">#63717a</color> <!-- special_report_main -->
+    <color name="specialReport_500">#abc2c9</color> <!-- special_report_bright -->
+    <color name="specialReport_800">#eff1f2</color> <!-- special_report_faded -->
+    <!-- endregion -->
+</resources>

--- a/android/source/src/main/res/values/palette.xml
+++ b/android/source/src/main/res/values/palette.xml
@@ -106,7 +106,23 @@
     <color name="specialReport_200">#303538</color>
     <color name="specialReport_300">#3f464a</color>
     <color name="specialReport_400">#595c5f</color>
+    <color name="specialReport_450">#9da0a2</color>
     <color name="specialReport_500">#abc2c9</color>
+    <color name="specialReport_700">#e4e5e8</color>
     <color name="specialReport_800">#eff1f2</color>
+    <!-- endregion -->
+    
+    <!-- region SpecialReportAlt -->
+    <color name="specialReportAlt_100">#2b2b2a</color>
+    <color name="specialReportAlt_200">#b9300a</color>
+    <color name="specialReportAlt_300">#ff663d</color>
+    <color name="specialReportAlt_700">#ebe6e1</color>
+    <color name="specialReportAlt_800">#f5f0eb</color>
+    <!-- endregion -->
+    
+    <!-- region Labs -->
+    <color name="labs_200">#0c7a73</color>
+    <color name="labs_300">#65a897</color>
+    <color name="labs_400">#69d1ca</color>
     <!-- endregion -->
 </resources>


### PR DESCRIPTION
#### Description

Updates palette colours based on @akemitakagi 's feedback [document.](https://docs.google.com/document/d/1chQ2EqUdkjvzqn8hHgAthCL84M-XWeQ2hQg0_BsrBsg/edit)

I've left the `opinion_300` in but marked it as deprecated with recommendation to use 400 instead.

Also added a sheet with all palette pills to the sample app (screenshot below).

#### Testing notes/instructions:

Build and run the sample app to see all the palette colours, and maybe confirm them with Akemi's sheet.

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: @akemitakagi 
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

![Palette](https://github.com/guardian/source-apps/assets/79363218/84471677-daed-4a50-a855-177d41bab014)

<!-- Do not delete this ↑ blank line or the table won't work -->
