### PR TITLE
Add button variant that allows custom colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Text(
 
 ### Buttons
 
-Two button components are available - `SourceButton` and `SourceIconButton`.
+Three button components are available - `SourceButton`, `SourceIconButton` and `PlainSourceButton`.
 
-The buttons are have preset style and size variants corresponding to Source presets. Both Core and Reader Revenue themes are also provided.
+The source buttons have preset style and size variants corresponding to Source specifications. Both Core and Reader Revenue themes are provided.
 
 Using `SourceButton`:
 ```kotlin
@@ -88,6 +88,30 @@ SourceIconButton(
     priority = SourceButton.Priority.SecondaryOnBlue,
     contentDescription = null,
     onClick = {},
+)
+```
+
+The plain button is intended for when custom colour schemes are used. It does not use preconfigured `priority` or `theme`. It can instead directly be provided with `ButtonColours`. (Plain button is available from version `0.2.1`)
+
+```kotlin
+PlainSourceButton(
+    text = "Culture themed",
+    onClick = {},
+    modifier = Modifier.align(CenterHorizontally),
+    buttonColours = ButtonColours(
+        border = AppColour(
+            light = Source.Palette.Culture200,
+            dark = Source.Palette.Culture800,
+        ),
+        container = AppColour(
+            light = Source.Palette.Culture800,
+            dark = Source.Palette.Culture200,
+        ),
+        content = AppColour(
+            light = Source.Palette.Culture200,
+            dark = Source.Palette.Culture800,
+        ),
+    ),
 )
 ```
 

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             AppColourMode {
-                Greeting("Android")
+                Greeting(name = "Android", modifier = it)
             }
         }
     }
@@ -99,21 +99,22 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
 
             Text(text = "Button variants", style = Source.Typography.TextSansBold17)
 
-            Row {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround,
+            ) {
                 SourceIconButton(
                     icon = Source.Icons.Base.Check,
                     priority = SourceButton.Priority.PrimaryOnWhite,
                     contentDescription = null,
                     onClick = {},
                     size = SourceButton.Size.XSmall,
-                    modifier = Modifier.weight(1f),
                 )
                 SourceButton(
-                    text = "Xsm core",
+                    text = "Extra small - Core",
                     priority = SourceButton.Priority.SecondaryOnWhite,
                     onClick = {},
                     size = SourceButton.Size.XSmall,
-                    modifier = Modifier.weight(1f),
                 )
                 SourceIconButton(
                     icon = Source.Icons.Base.Check,
@@ -121,26 +122,26 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                     contentDescription = null,
                     onClick = {},
                     size = SourceButton.Size.XSmall,
-                    modifier = Modifier.weight(1f),
                 )
             }
 
             ReaderRevenueTheme {
-                Row(modifier = it) {
+                Row(
+                    modifier = it.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceAround,
+                ) {
                     SourceIconButton(
                         icon = Source.Icons.Base.Check,
                         priority = SourceButton.Priority.PrimaryOnWhite,
                         contentDescription = null,
                         onClick = {},
                         size = SourceButton.Size.Small,
-                        modifier = Modifier.weight(1f),
                     )
                     SourceButton(
-                        text = "Sm RR",
+                        text = "Small - RR",
                         priority = SourceButton.Priority.PrimaryOnWhite,
                         onClick = {},
                         size = SourceButton.Size.Small,
-                        modifier = Modifier.weight(1f),
                     )
                     SourceIconButton(
                         icon = Source.Icons.Base.Check,
@@ -148,26 +149,26 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                         contentDescription = null,
                         onClick = {},
                         size = SourceButton.Size.Small,
-                        modifier = Modifier.weight(1f),
                     )
                 }
             }
 
-            Row {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround,
+            ) {
                 SourceIconButton(
                     icon = Source.Icons.Base.Check,
                     priority = SourceButton.Priority.PrimaryOnWhite,
                     contentDescription = null,
                     onClick = {},
                     size = SourceButton.Size.Medium,
-                    modifier = Modifier.weight(1f),
                 )
                 SourceButton(
-                    text = "Md Core",
+                    text = "Medium - Core",
                     priority = SourceButton.Priority.SecondaryOnWhite,
                     onClick = {},
                     size = SourceButton.Size.Medium,
-                    modifier = Modifier.weight(1f),
                 )
                 SourceIconButton(
                     icon = Source.Icons.Base.Check,
@@ -175,19 +176,26 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                     contentDescription = null,
                     onClick = {},
                     size = SourceButton.Size.Medium,
-                    modifier = Modifier.weight(1f),
                 )
             }
 
             PlainSourceButton(
-                text = "Un-themed",
-                size = SourceButton.Size.Small,
+                text = "Custom themed",
                 onClick = {},
                 modifier = Modifier.align(CenterHorizontally),
                 buttonColours = ButtonColours(
-                    border = AppColour(Source.Palette.Culture200, Source.Palette.Culture800),
-                    container = AppColour(Source.Palette.Culture800, Source.Palette.Culture200),
-                    content = AppColour(Source.Palette.Culture200, Source.Palette.Culture800),
+                    border = AppColour(
+                        light = Source.Palette.Culture200,
+                        dark = Source.Palette.Culture800,
+                    ),
+                    container = AppColour(
+                        light = Source.Palette.Culture800,
+                        dark = Source.Palette.Culture200,
+                    ),
+                    content = AppColour(
+                        light = Source.Palette.Culture200,
+                        dark = Source.Palette.Culture800,
+                    ),
                 ),
             )
         }

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.gu.source
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,7 +8,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -37,6 +37,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@SuppressLint("DiscouragedApi")
 @Composable
 private fun Greeting(name: String, modifier: Modifier = Modifier) {
     val coroutineScope = rememberCoroutineScope()
@@ -55,11 +56,11 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
             Source.Palette.Neutral0,
         ).current,
         modifier = modifier,
-    ) {
+    ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(it + PaddingValues(16.dp)),
+                .padding(paddingValues + PaddingValues(16.dp)),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
@@ -86,7 +87,7 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
             SourceButton(
                 text = "Open palette",
                 priority = SourceButton.Priority.TertiaryOnWhite,
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier = Modifier.align(CenterHorizontally),
                 onClick = {
                     coroutineScope.launch {
                         scaffoldState.bottomSheetState.expand()
@@ -181,13 +182,13 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
             PlainSourceButton(
                 text = "Un-themed",
                 size = SourceButton.Size.Small,
-                buttonColours = ButtonColours(
-                    border = AppColour(Source.Palette.Culture200),
-                    container = AppColour(Source.Palette.Culture800),
-                    content = AppColour(Source.Palette.Culture200),
-                ),
                 onClick = {},
                 modifier = Modifier.align(CenterHorizontally),
+                buttonColours = ButtonColours(
+                    border = AppColour(Source.Palette.Culture200, Source.Palette.Culture800),
+                    container = AppColour(Source.Palette.Culture800, Source.Palette.Culture200),
+                    content = AppColour(Source.Palette.Culture200, Source.Palette.Culture800),
+                ),
             )
         }
     }

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -8,17 +8,17 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.gu.source.components.buttons.ButtonColours
+import com.gu.source.components.buttons.PlainSourceButton
 import com.gu.source.components.buttons.SourceButton
 import com.gu.source.components.buttons.SourceIconButton
 import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
 import com.gu.source.icons.Check
-import com.gu.source.presets.palette.Brand400
-import com.gu.source.presets.palette.Neutral0
-import com.gu.source.presets.palette.Neutral100
-import com.gu.source.presets.palette.Neutral97
+import com.gu.source.presets.palette.*
 import com.gu.source.presets.typography.HeadlineMedium20
 import com.gu.source.presets.typography.TextSansBold17
 import com.gu.source.theme.ReaderRevenueTheme
@@ -108,7 +108,7 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                     modifier = Modifier.weight(1f),
                 )
                 SourceButton(
-                    text = "Welcome",
+                    text = "Xsm core",
                     priority = SourceButton.Priority.SecondaryOnWhite,
                     onClick = {},
                     size = SourceButton.Size.XSmall,
@@ -135,7 +135,7 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                         modifier = Modifier.weight(1f),
                     )
                     SourceButton(
-                        text = "to",
+                        text = "Sm RR",
                         priority = SourceButton.Priority.PrimaryOnWhite,
                         onClick = {},
                         size = SourceButton.Size.Small,
@@ -162,7 +162,7 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                     modifier = Modifier.weight(1f),
                 )
                 SourceButton(
-                    text = "Source",
+                    text = "Md Core",
                     priority = SourceButton.Priority.SecondaryOnWhite,
                     onClick = {},
                     size = SourceButton.Size.Medium,
@@ -177,6 +177,18 @@ private fun Greeting(name: String, modifier: Modifier = Modifier) {
                     modifier = Modifier.weight(1f),
                 )
             }
+
+            PlainSourceButton(
+                text = "Un-themed",
+                size = SourceButton.Size.Small,
+                buttonColours = ButtonColours(
+                    border = AppColour(Source.Palette.Culture200),
+                    container = AppColour(Source.Palette.Culture800),
+                    content = AppColour(Source.Palette.Culture200),
+                ),
+                onClick = {},
+                modifier = Modifier.align(CenterHorizontally),
+            )
         }
     }
 }

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/ButtonColours.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/ButtonColours.kt
@@ -1,5 +1,6 @@
 package com.gu.source.components.buttons
 
+import androidx.compose.ui.graphics.Color
 import com.gu.source.Source
 import com.gu.source.Source.Theme.Core
 import com.gu.source.Source.Theme.ReaderRevenue
@@ -17,7 +18,21 @@ data class ButtonColours(
     val border: AppColour,
     val container: AppColour,
     val content: AppColour,
-)
+) {
+    /**
+     * Secondary constructor to allow creating an instance without using `AppColour`. This can be
+     * used when loading colours from resources using `colourResource`.
+     */
+    constructor(
+        border: Color,
+        container: Color,
+        content: Color,
+    ) : this(
+        border = AppColour(light = border),
+        container = AppColour(container),
+        content = AppColour(content),
+    )
+}
 
 @Suppress("CyclomaticComplexMethod", "LongMethod")
 /**

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/ButtonColours.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/ButtonColours.kt
@@ -7,7 +7,13 @@ import com.gu.source.components.buttons.SourceButton.Priority.*
 import com.gu.source.daynight.AppColour
 import com.gu.source.presets.palette.*
 
-internal data class ButtonColours(
+/**
+ * Model to provide colours for a button.
+ * @property border
+ * @property container
+ * @property content Colour for the content of the button including text and icons.
+ */
+data class ButtonColours(
     val border: AppColour,
     val container: AppColour,
     val content: AppColour,

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -88,10 +88,10 @@ fun PlainSourceContentButton(
  * Prefer to use [SourceButton] or [SourceBaseIconButton] instead.
  *
  * @param text Text to display on the button.
- * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
  * @param onClick Callback for action to take when user clicks the button.
  * @param modifier Optional [Modifier]
  * @param buttonColours Optional colours for the button. Use this to theme the button.
+ * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
  * @param iconSide Optional the side of the button on which the icon appears. Defaults to
  * [SourceButton.IconSide.Left].
  * @param icon Optional icon to display on the button.
@@ -99,10 +99,10 @@ fun PlainSourceContentButton(
 @Composable
 fun PlainSourceButton(
     text: String,
-    size: SourceButton.Size,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     buttonColours: ButtonColours = PlainDefault,
+    size: SourceButton.Size = SourceButton.Size.Small,
     iconSide: SourceButton.IconSide = SourceButton.IconSide.Left,
     icon: @Composable (Modifier) -> Unit = {},
 ) {
@@ -143,7 +143,7 @@ fun PlainSourceButton(
 private fun Preview() {
     PlainSourceButton(
         text = "Button",
-        size = SourceButton.Size.Small,
         onClick = {},
+        size = SourceButton.Size.Small,
     )
 }

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -1,0 +1,149 @@
+package com.gu.source.components.buttons
+
+import android.annotation.SuppressLint
+import androidx.annotation.Discouraged
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gu.source.Source
+import com.gu.source.daynight.AppColour
+import com.gu.source.presets.palette.Sport200
+import com.gu.source.presets.palette.Sport800
+
+/**
+ * A basic Source compatible button component. This button does not have any Source colour theming.
+ * This is a low-level component and should be sparingly used only for custom buttons. Prefer to
+ * use [SourceButton] or [SourceBaseIconButton] instead.
+ *
+ * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
+ * @param buttonColours Colours for the button. Use [ButtonColours] to create the colours.
+ * @param onClick Callback for action to take when user clicks the button.
+ * @param modifier Optional [Modifier]
+ * @param content Slot for composable content to present inside the button.
+ */
+@Discouraged(
+    "Preferably use `SourceButton`." +
+        " It provides correct styling & size for text and icons." +
+        " This variant is for supporting custom button designs only.",
+)
+@Composable
+fun PlainSourceContentButton(
+    size: SourceButton.Size,
+    buttonColours: ButtonColours,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.defaultMinSize(
+            minWidth = SourceButton.MinButtonWidth,
+            minHeight = size.heightDp.dp,
+        ),
+        shape = CircleShape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = buttonColours.container.current,
+            contentColor = buttonColours.content.current,
+        ),
+        elevation = ButtonDefaults.buttonElevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+            focusedElevation = 0.dp,
+            hoveredElevation = 0.dp,
+            disabledElevation = 0.dp,
+        ),
+        border = BorderStroke(
+            width = 1.dp,
+            color = buttonColours.border.current,
+        ),
+        contentPadding = size.contentPadding,
+        content = { content() },
+    )
+}
+
+/**
+ * A plain Source button component with text and an optional icon, but no Source colour theming.
+ *
+ * Prefer to use [SourceButton] or [SourceBaseIconButton] instead.
+ *
+ * @param text Text to display on the button.
+ * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
+ * @param buttonColours Colours for the button. Use [ButtonColours] to create the colours.
+ * @param onClick Callback for action to take when user clicks the button.
+ * @param modifier Optional [Modifier]
+ * @param iconSide Optional the side of the button on which the icon appears. Defaults to
+ * [SourceButton.IconSide.Left].
+ * @param icon Optional icon to display on the button.
+ */
+@SuppressLint("DiscouragedApi")
+@Discouraged(
+    "Preferably use `SourceButton`." +
+        " It provides correct styling & size for text and icons." +
+        " This variant is for supporting custom button designs and colours only.",
+)
+@Composable
+fun PlainSourceButton(
+    text: String,
+    size: SourceButton.Size,
+    buttonColours: ButtonColours,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconSide: SourceButton.IconSide = SourceButton.IconSide.Left,
+    icon: @Composable (Modifier) -> Unit = {},
+) {
+    PlainSourceContentButton(
+        size = size,
+        buttonColours = buttonColours,
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (iconSide == SourceButton.IconSide.Left) {
+                icon(Modifier.size(size.textStyle.fontSize.value.dp))
+            }
+
+            Text(
+                text = text,
+                style = size.textStyle,
+                overflow = TextOverflow.Ellipsis,
+                softWrap = false,
+                maxLines = 1,
+                letterSpacing = 0.sp,
+                modifier = Modifier.offset(y = (-1).dp),
+            )
+
+            if (iconSide == SourceButton.IconSide.Right) {
+                icon(Modifier.size(size.textStyle.fontSize.value.dp))
+            }
+        }
+    }
+}
+
+@SuppressLint("DiscouragedApi")
+@Preview
+@Composable
+private fun Preview() {
+    PlainSourceButton(
+        text = "Button",
+        size = SourceButton.Size.Small,
+        buttonColours = ButtonColours(
+            border = AppColour(Source.Palette.Sport200),
+            container = AppColour(Source.Palette.Sport800),
+            content = AppColour(Source.Palette.Sport200),
+        ),
+        onClick = {},
+    )
+}

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
 import com.gu.source.daynight.AppColour
-import com.gu.source.presets.palette.Sport200
-import com.gu.source.presets.palette.Sport800
+import com.gu.source.presets.palette.Culture200
+import com.gu.source.presets.palette.Culture800
 
 /**
  * A basic Source compatible button component. This button does not have any Source colour theming.
@@ -140,9 +140,9 @@ private fun Preview() {
         text = "Button",
         size = SourceButton.Size.Small,
         buttonColours = ButtonColours(
-            border = AppColour(Source.Palette.Sport200),
-            container = AppColour(Source.Palette.Sport800),
-            content = AppColour(Source.Palette.Sport200),
+            border = AppColour(Source.Palette.Culture200),
+            container = AppColour(Source.Palette.Culture800),
+            content = AppColour(Source.Palette.Culture200),
         ),
         onClick = {},
     )

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -16,31 +16,42 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
-import com.gu.source.presets.palette.Culture200
-import com.gu.source.presets.palette.Culture800
+import com.gu.source.daynight.AppColour
+import com.gu.source.presets.palette.Neutral0
+import com.gu.source.presets.palette.Neutral100
+
+private val PlainDefault: ButtonColours
+    get() = ButtonColours(
+        border = AppColour(Source.Palette.Neutral0, Source.Palette.Neutral100),
+        container = AppColour.Transparent,
+        content = AppColour(Source.Palette.Neutral0, Source.Palette.Neutral100),
+    )
 
 /**
- * A basic Source compatible button component. This button does not have any Source colour theming.
+ * A plain, basic Source compatible button component. This button does not have any Source colour
+ * theming. Provide [buttonColours] to theme the button.
+ *
+ *
  * This is a low-level component and should be sparingly used only for custom buttons. Prefer to
- * use [SourceButton] or [SourceBaseIconButton] instead.
+ * use [PlainSourceButton] or [SourceIconButton] instead.
  *
  * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
- * @param buttonColours Colours for the button. Use [ButtonColours] to create the colours.
  * @param onClick Callback for action to take when user clicks the button.
  * @param modifier Optional [Modifier]
+ * @param buttonColours Optional colours for the button. Use this to theme the button.
  * @param content Slot for composable content to present inside the button.
  */
 @Discouraged(
-    "Preferably use `SourceButton`." +
+    "Preferably use `PlainSourceButton`." +
         " It provides correct styling & size for text and icons." +
         " This variant is for supporting custom button designs only.",
 )
 @Composable
 fun PlainSourceContentButton(
     size: SourceButton.Size,
-    buttonColours: ButtonColours,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    buttonColours: ButtonColours = PlainDefault,
     content: @Composable () -> Unit,
 ) {
     Button(
@@ -71,40 +82,35 @@ fun PlainSourceContentButton(
 }
 
 /**
- * A plain Source button component with text and an optional icon, but no Source colour theming.
+ * A plain Source button component with text and an optional icon. This has no Source colour
+ * theming. Provide [buttonColours] to theme the button.
  *
  * Prefer to use [SourceButton] or [SourceBaseIconButton] instead.
  *
  * @param text Text to display on the button.
  * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
- * @param buttonColours Colours for the button. Use [ButtonColours] to create the colours.
  * @param onClick Callback for action to take when user clicks the button.
  * @param modifier Optional [Modifier]
+ * @param buttonColours Optional colours for the button. Use this to theme the button.
  * @param iconSide Optional the side of the button on which the icon appears. Defaults to
  * [SourceButton.IconSide.Left].
  * @param icon Optional icon to display on the button.
  */
-@SuppressLint("DiscouragedApi")
-@Discouraged(
-    "Preferably use `SourceButton`." +
-        " It provides correct styling & size for text and icons." +
-        " This variant is for supporting custom button designs and colours only.",
-)
 @Composable
 fun PlainSourceButton(
     text: String,
     size: SourceButton.Size,
-    buttonColours: ButtonColours,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    buttonColours: ButtonColours = PlainDefault,
     iconSide: SourceButton.IconSide = SourceButton.IconSide.Left,
     icon: @Composable (Modifier) -> Unit = {},
 ) {
     PlainSourceContentButton(
         size = size,
-        buttonColours = buttonColours,
         onClick = onClick,
         modifier = modifier,
+        buttonColours = buttonColours,
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -138,11 +144,6 @@ private fun Preview() {
     PlainSourceButton(
         text = "Button",
         size = SourceButton.Size.Small,
-        buttonColours = ButtonColours(
-            border = Source.Palette.Culture200,
-            container = Source.Palette.Culture800,
-            content = Source.Palette.Culture200,
-        ),
         onClick = {},
     )
 }

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
-import com.gu.source.daynight.AppColour
 import com.gu.source.presets.palette.Culture200
 import com.gu.source.presets.palette.Culture800
 
@@ -140,9 +139,9 @@ private fun Preview() {
         text = "Button",
         size = SourceButton.Size.Small,
         buttonColours = ButtonColours(
-            border = AppColour(Source.Palette.Culture200),
-            container = AppColour(Source.Palette.Culture800),
-            content = AppColour(Source.Palette.Culture200),
+            border = Source.Palette.Culture200,
+            container = Source.Palette.Culture800,
+            content = Source.Palette.Culture200,
         ),
         onClick = {},
     )

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -3,12 +3,8 @@ package com.gu.source.components.buttons
 import android.annotation.SuppressLint
 import androidx.annotation.Discouraged
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,7 +15,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
-import com.gu.source.components.buttons.SourceButton.MinButtonWidth
 import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
 import com.gu.source.icons.Check
@@ -104,10 +99,12 @@ object SourceButton {
                 light = Source.Palette.Neutral100,
                 dark = Source.Palette.Neutral7,
             )
+
             name.endsWith("OnBlue") -> AppColour(
                 light = Source.Palette.Brand400,
                 dark = Source.Palette.Neutral7,
             )
+
             else -> AppColour.Unspecified
         }
     }
@@ -137,6 +134,7 @@ object SourceButton {
  * child components once.
  * @param content Slot for composable content to present inside the button.
  */
+@SuppressLint("DiscouragedApi")
 @Discouraged(
     "Preferably use `SourceButton`." +
         " It provides correct styling & size for text and icons." +
@@ -159,30 +157,12 @@ fun SourceContentButton(
 
     val buttonColours = priority.toColours(appliedTheme)
 
-    Button(
+    PlainSourceContentButton(
+        size = size,
+        buttonColours = buttonColours,
         onClick = onClick,
-        modifier = modifier.defaultMinSize(
-            minWidth = MinButtonWidth,
-            minHeight = size.heightDp.dp,
-        ),
-        shape = CircleShape,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = buttonColours.container.current,
-            contentColor = buttonColours.content.current,
-        ),
-        elevation = ButtonDefaults.buttonElevation(
-            defaultElevation = 0.dp,
-            pressedElevation = 0.dp,
-            focusedElevation = 0.dp,
-            hoveredElevation = 0.dp,
-            disabledElevation = 0.dp,
-        ),
-        border = BorderStroke(
-            width = 1.dp,
-            color = buttonColours.border.current,
-        ),
-        contentPadding = size.contentPadding,
-        content = { content() },
+        modifier = modifier,
+        content = content,
     )
 }
 

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -119,7 +119,7 @@ object SourceButton {
 /**
  * A basic Source compatible button component.
  * This is a low-level component and should be sparingly used only for custom buttons. Prefer to
- * use [SourceButton] or [SourceBaseIconButton] instead.
+ * use [SourceButton] or [SourceIconButton] instead.
  *
  * @param size Button size from [SourceButton.Size]s. Reflects the prominence of the action.
  * @param priority Button priority from [SourceButton.Priority]s. Informs users of how important an
@@ -159,9 +159,9 @@ fun SourceContentButton(
 
     PlainSourceContentButton(
         size = size,
-        buttonColours = buttonColours,
         onClick = onClick,
         modifier = modifier,
+        buttonColours = buttonColours,
         content = content,
     )
 }

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -142,7 +142,7 @@ object SourceButton {
         " This variant is for supporting custom button designs only.",
 )
 @Composable
-fun SourceBaseButton(
+fun SourceContentButton(
     size: SourceButton.Size,
     priority: SourceButton.Priority,
     onClick: () -> Unit,
@@ -216,7 +216,7 @@ fun SourceButton(
     iconSide: SourceButton.IconSide = SourceButton.IconSide.Left,
     icon: @Composable (Modifier) -> Unit = {},
 ) {
-    SourceBaseButton(
+    SourceContentButton(
         size = size,
         priority = priority,
         onClick = onClick,

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -1,5 +1,6 @@
 package com.gu.source.components.buttons
 
+import android.annotation.SuppressLint
 import androidx.annotation.Discouraged
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.BorderStroke
@@ -205,6 +206,7 @@ fun SourceContentButton(
  * [SourceButton.IconSide.Left].
  * @param icon Optional icon to display on the button.
  */
+@SuppressLint("DiscouragedApi")
 @Composable
 fun SourceButton(
     text: String,
@@ -249,6 +251,7 @@ fun SourceButton(
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+@SuppressLint("DiscouragedApi")
 @PhoneBothModePreviews
 @Composable
 internal fun CoreButtonIconBeforePreview() {
@@ -285,6 +288,7 @@ internal fun CoreButtonIconBeforePreview() {
     }
 }
 
+@SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @PhoneBothModePreviews
 @Composable
@@ -384,6 +388,7 @@ internal fun RrButtonTextOnlyPreview() {
     }
 }
 
+@SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @PhoneBothModePreviews
 @Composable
@@ -421,6 +426,7 @@ internal fun CoreButtonIconAfterPreview() {
     }
 }
 
+@SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @PhoneBothModePreviews
 @Composable


### PR DESCRIPTION
#### Description

Created `PlainSourceButton` and `PlainSourceContentButton` variants. These take a `ButtonColours` object instead of `theme` and `priority`. They are intended to be used for custom colour combinations.

#### Testing notes/instructions:

Check out the unthemed button in sample.

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
