### PR TITLE
Use token auth for Sonatype

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           env:
             AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
             AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}
-            AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+            AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
           run: |
             cd android
             ./gradlew :source:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,10 +23,11 @@ version = libs.versions.libraryVersion.get()
 nexusPublishing {
     repositories {
         sonatype {
+            // Sonatype token provides username and passwords as revokable secrets combined with a
+            // colon. We split them and provide it to the nexus plugin. See here for more:
+            // https://github.com/guardian/gha-scala-library-release-workflow/commit/23a148a03cf71bb2093a91f047d3c368adcdf45c
             val (uname, pwd) = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
                 .split(":")
-//            username = "guardian.automated.maven.release"
-//            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
             username = uname
             password = pwd
         }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -26,8 +26,8 @@ nexusPublishing {
             // Sonatype token provides username and passwords as revokable secrets combined with a
             // colon. We split them and provide it to the nexus plugin. See here for more:
             // https://github.com/guardian/gha-scala-library-release-workflow/commit/23a148a03cf71bb2093a91f047d3c368adcdf45c
-            val (uname, pwd) = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
-                .split(":")
+            val token = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN") ?: ":"
+            val (uname, pwd) = token.split(":")
             username = uname
             password = pwd
         }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,8 +23,12 @@ version = libs.versions.libraryVersion.get()
 nexusPublishing {
     repositories {
         sonatype {
-            username = "guardian.automated.maven.release"
-            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
+            val (uname, pwd) = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
+                .split(":")
+//            username = "guardian.automated.maven.release"
+//            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
+            username = uname
+            password = pwd
         }
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -24,7 +24,7 @@ nexusPublishing {
     repositories {
         sonatype {
             username = "guardian.automated.maven.release"
-            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD")
+            password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN")
         }
     }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.2.1"
+libraryVersion = "0.2.2"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "33"


### PR DESCRIPTION
Use token auth for Sonatype - see https://github.com/guardian/gha-scala-library-release-workflow/pull/23