### PR TITLE
iOS - Update disabled opacity of icon button 

### DIFF
--- a/Sources/Source/Components/Buttons/IconButton.swift
+++ b/Sources/Source/Components/Buttons/IconButton.swift
@@ -16,7 +16,7 @@ public struct IconButton: View {
         size: ButtonSize,
         iconColor: Color,
         borderColor: Color,
-        disabled: Binding<Bool>,
+        disabled: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
     ) {
         self.icon = icon
@@ -49,18 +49,25 @@ struct IconButtonStyle: ButtonStyle {
     let borderColor: Color
     let iconColor: Color
 
-    init(size: ButtonSize, isDisabled: Binding<Bool>, borderColor: Color, iconColor: Color) {
+    @Environment(\.colorScheme) private
+    var colorScheme
+
+    init(size: ButtonSize, isDisabled: Binding<Bool> = .constant(false), borderColor: Color, iconColor: Color) {
         self.size = size
         self._isDisabled = isDisabled
         self.borderColor = borderColor
         self.iconColor = iconColor
     }
 
+    private var disabledOpacity: CGFloat {
+        return colorScheme == .dark ? 0.4 : 0.2
+    }
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(width: size.iconSize, height: size.iconSize)
             .foregroundStyle(iconColor)
-            .opacity(isDisabled ? 0.2 : 1.0)
+            .opacity(isDisabled ? disabledOpacity : 1.0)
             .padding(size.iconPadding)
             .background {
                 if configuration.isPressed, isDisabled == false {


### PR DESCRIPTION
#### Description
Small PR to update the disabled opacity in dark mode, this manages the design approach we've taken for the secondary colour - in that in dark mode it is 40% rather than 20% so that it's more visible. 
I've also made a small change to the `IconButton` initialiser so that the `disabled` property takes a default value of false since it is in rare occasions this is likely to be used. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| `Before` | `After` |
| --- | --- |
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-25 at 14 52 48](https://github.com/user-attachments/assets/f3e51a13-f23f-49f7-83f0-94df155d1588) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-25 at 14 49 51](https://github.com/user-attachments/assets/a8e1a6d4-e952-49b2-8db4-b372f8565b2d)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-25 at 14 52 50](https://github.com/user-attachments/assets/1a565947-071a-4161-b63c-cd83e7069a3f) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-25 at 14 49 48](https://github.com/user-attachments/assets/37b25f55-abe8-44a5-803e-d5555514c126)


<!-- Do not delete this ↑ blank line or the table won't work -->
