### PR TITLE
iOS - Animate change of index triggered by progress button 

### DIFF
--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -70,7 +70,9 @@ public struct PaginationProgressBar: View {
                 borderColor: secondaryColor,
                 disabled: $canNavigateBack
             ) {
-                selectedIndex -= 1
+                withAnimation {
+                    selectedIndex -= 1
+                }
             }
             IconButton(
                 icon: Image(.chevronRight),
@@ -79,7 +81,9 @@ public struct PaginationProgressBar: View {
                 borderColor: secondaryColor,
                 disabled: $canNavigateForward
             ) {
-                selectedIndex += 1
+                withAnimation {
+                    selectedIndex += 1
+                }
             }
         }
     }


### PR DESCRIPTION
#### Description
This PR animates the change to the selected index triggered by the buttons within the `PaginationProgressBar` - this allows the images in the slideshow to animate into view. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| `Before` | `After` |
| --- | --- |
https://github.com/user-attachments/assets/c2a2227d-4466-4a2f-9cb3-6168ea27df42 | https://github.com/user-attachments/assets/0771a8c2-7cfc-411f-bfb5-59cb49ac5e05



<!-- Do not delete this ↑ blank line or the table won't work -->
