### PR TITLE
iOS - Update icon sizes and padding 

### DIFF
--- a/Sources/Source/Components/Buttons/IconButton.swift
+++ b/Sources/Source/Components/Buttons/IconButton.swift
@@ -90,22 +90,22 @@ fileprivate extension ButtonSize {
     var iconSize: CGFloat {
         switch self {
             case .xsmall:
-                return 14
+                return 20
             case .small:
-                return 18
+                return 24
             case .medium:
-                return 22
+                return 28
         }
     }
 
     var iconPadding: CGFloat {
         switch self {
             case .xsmall:
-                return 5
+                return 2
             case .small:
-                return 9
+                return 6
             case .medium:
-                return 11
+                return 8
         }
     }
 }


### PR DESCRIPTION
#### Description

As spotted in this [PR](https://github.com/guardian/ios-live/pull/8038#issuecomment-2258456518) - the icon presets were too small, since the icon svg already have their own padding. 
This PR updates the sizing and padding so that the total size still matches that set in the design system 

#### Testing notes/instructions:
This can be tested as part of the PR on iOS live - I have added a screenshot from that branch here to confirm the impact on the size of the chevron. 

#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| `Before` | `After` |
| --- | --- |
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-29 at 17 34 42](https://github.com/user-attachments/assets/f22457e9-c8d1-4205-b66e-8c60dfae561c) | ![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-31 at 09 09 13](https://github.com/user-attachments/assets/fdc60856-7fcf-464b-ab4c-60e58e38fb7c)


<!-- Do not delete this ↑ blank line or the table won't work -->
