### PR TITLE
Update multi preview annotations to add scaled font preview

### DIFF
--- a/android/config/detekt.yml
+++ b/android/config/detekt.yml
@@ -781,8 +781,8 @@ style:
     allowedNames: ''
     ignoreAnnotated:
       - 'Preview'
-      - 'PhoneBothModePreviews'
-      - 'TabletBothModePreviews'
+      - 'PreviewPhoneBothMode'
+      - 'PreviewTabletBothMode'
   UnusedPrivateProperty:
     active: true
     allowedNames: '_|ignored|expected|serialVersionUID'

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.3.3"
+libraryVersion = "0.3.4"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "34"

--- a/android/sample/src/main/kotlin/com/gu/source/ImagePagerWithProgressIndicator.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/ImagePagerWithProgressIndicator.kt
@@ -18,8 +18,8 @@ import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
 import com.gu.source.presets.palette.Neutral10
 import com.gu.source.presets.palette.Neutral100
-import com.gu.source.utils.PhoneBothModePreviews
-import com.gu.source.utils.TabletBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
+import com.gu.source.utils.PreviewTabletBothMode
 
 @Suppress("MagicNumber")
 @Composable
@@ -46,8 +46,8 @@ internal fun ImagePagerWithProgressIndicator(modifier: Modifier = Modifier) {
     }
 }
 
-@PhoneBothModePreviews
-@TabletBothModePreviews
+@PreviewPhoneBothMode
+@PreviewTabletBothMode
 @Composable
 private fun Preview() {
     AppColourMode {

--- a/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
+++ b/android/sample/src/main/kotlin/com/gu/source/MainActivity.kt
@@ -21,7 +21,7 @@ import com.gu.source.presets.palette.Neutral10
 import com.gu.source.presets.palette.Neutral100
 import com.gu.source.presets.palette.Neutral97
 import com.gu.source.presets.typography.HeadlineMedium20
-import com.gu.source.utils.PhoneBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
 import com.gu.source.utils.plus
 import kotlinx.coroutines.launch
 
@@ -141,7 +141,7 @@ private fun Greeting(modifier: Modifier = Modifier) {
     }
 }
 
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 private fun GreetingPreview() {
     AppColourMode {

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/PlainSourceButton.kt
@@ -20,7 +20,7 @@ import com.gu.source.Source
 import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
 import com.gu.source.presets.palette.*
-import com.gu.source.utils.PhoneBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
 
 private val PlainDefault: ButtonColours
     get() = ButtonColours(
@@ -176,7 +176,7 @@ fun PlainSourceButton(
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun PlainSourceButtonPreview() {
     AppColourMode {

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -275,6 +275,7 @@ internal fun CoreButtonIconBeforePreview() {
 }
 
 @SuppressLint("DiscouragedApi")
+@Suppress("StringLiteralDuplication")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @PreviewPhoneBothMode
 @Composable

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceButton.kt
@@ -27,7 +27,7 @@ import com.gu.source.presets.typography.TextSansBold17
 import com.gu.source.theme.LocalSourceTheme
 import com.gu.source.theme.ReaderRevenueTheme
 import com.gu.source.theme.SourceCoreTheme
-import com.gu.source.utils.PhoneBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
 
 /**
  * Object for property models for the [SourceButton] component.
@@ -238,7 +238,7 @@ fun SourceButton(
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @SuppressLint("DiscouragedApi")
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun CoreButtonIconBeforePreview() {
     AppColourMode {
@@ -276,7 +276,7 @@ internal fun CoreButtonIconBeforePreview() {
 
 @SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun RrButtonIconBeforePreview() {
     AppColourMode {
@@ -315,7 +315,7 @@ internal fun RrButtonIconBeforePreview() {
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun CoreButtonTextOnlyPreview() {
     AppColourMode {
@@ -344,7 +344,7 @@ internal fun CoreButtonTextOnlyPreview() {
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun RrButtonTextOnlyPreview() {
     AppColourMode {
@@ -376,7 +376,7 @@ internal fun RrButtonTextOnlyPreview() {
 
 @SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun CoreButtonIconAfterPreview() {
     AppColourMode {
@@ -414,7 +414,7 @@ internal fun CoreButtonIconAfterPreview() {
 
 @SuppressLint("DiscouragedApi")
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun RrButtonIconAfterPreview() {
     AppColourMode {

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceIconButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceIconButton.kt
@@ -24,7 +24,7 @@ import com.gu.source.presets.palette.*
 import com.gu.source.theme.LocalSourceTheme
 import com.gu.source.theme.ReaderRevenueTheme
 import com.gu.source.theme.SourceCoreTheme
-import com.gu.source.utils.PhoneBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
 
 private const val ReaderRevenueSecondaryThemeErrorMessage =
     "ReaderRevenue theme doesn't have secondary buttons."
@@ -247,7 +247,7 @@ fun SourceIconButton(
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun CoreIconButtonPreview() {
     AppColourMode {
@@ -277,7 +277,7 @@ internal fun CoreIconButtonPreview() {
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun RrIconButtonPreview() {
     AppColourMode {
@@ -309,7 +309,7 @@ internal fun RrIconButtonPreview() {
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@PhoneBothModePreviews
+@PreviewPhoneBothMode
 @Composable
 internal fun SourceBaseIconButtonPreview() {
     AppColourMode {

--- a/android/source/src/main/kotlin/com/gu/source/components/pager/PagerProgressBar.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/pager/PagerProgressBar.kt
@@ -33,8 +33,8 @@ import com.gu.source.icons.ChevronRight
 import com.gu.source.presets.palette.*
 import com.gu.source.presets.typography.Titlepiece70
 import com.gu.source.theme.LocalSourceTheme
-import com.gu.source.utils.PhoneBothModePreviews
-import com.gu.source.utils.TabletBothModePreviews
+import com.gu.source.utils.PreviewPhoneBothMode
+import com.gu.source.utils.PreviewTabletBothMode
 import com.gu.source.utils.isTabletDevice
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -277,8 +277,8 @@ private fun ProgressButtons(
 }
 
 @Suppress("MagicNumber")
-@PhoneBothModePreviews
-@TabletBothModePreviews
+@PreviewPhoneBothMode
+@PreviewTabletBothMode
 @Composable
 private fun AnimatedPreview() {
     AppColourMode {
@@ -342,8 +342,8 @@ private fun AnimatedPreview() {
 }
 
 @Suppress("MagicNumber")
-@PhoneBothModePreviews
-@TabletBothModePreviews
+@PreviewPhoneBothMode
+@PreviewTabletBothMode
 @Composable
 internal fun PagerProgressBarPreview() {
     AppColourMode {

--- a/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
+++ b/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
     backgroundColor = 0xFF000000,
     showBackground = true,
 )
-annotation class PhoneBothModePreviews
+annotation class PreviewPhoneBothMode
 
 /** Creates two previews on a Pixel tablet device for light and dark mode. */
 @Preview(
@@ -39,3 +39,4 @@ annotation class PhoneBothModePreviews
     showBackground = true,
 )
 annotation class TabletBothModePreviews
+annotation class PreviewTabletBothMode

--- a/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
+++ b/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:compose:preview-annotation-naming")
-
 package com.gu.source.utils
 
 import android.content.res.Configuration
@@ -8,35 +6,50 @@ import androidx.compose.ui.tooling.preview.Preview
 
 /** Creates two previews on a Pixel 7 device for light and dark mode. */
 @Preview(
-    name = "Pixel 7 day mode",
+    name = "Day mode",
     device = Devices.PIXEL_7,
     uiMode = Configuration.UI_MODE_NIGHT_NO,
     backgroundColor = 0xFFFFFFFF,
     showBackground = true,
 )
 @Preview(
-    name = "Pixel 7 night mode",
+    name = "Night mode",
     device = Devices.PIXEL_7,
     uiMode = Configuration.UI_MODE_NIGHT_YES,
     backgroundColor = 0xFF000000,
     showBackground = true,
+)
+@Preview(
+    name = "Scaled font",
+    device = Devices.PIXEL_7,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    showBackground = true,
+    fontScale = 1.5f,
 )
 annotation class PreviewPhoneBothMode
 
 /** Creates two previews on a Pixel tablet device for light and dark mode. */
 @Preview(
-    name = "Pixel tablet day mode",
+    name = "Day mode",
     device = "spec:parent=pixel_tablet,orientation=portrait",
     uiMode = Configuration.UI_MODE_NIGHT_NO,
     backgroundColor = 0xFFFFFFFF,
     showBackground = true,
 )
 @Preview(
-    name = "Pixel tablet night mode",
+    name = "Night mode",
     device = "spec:parent=pixel_tablet,orientation=portrait",
     uiMode = Configuration.UI_MODE_NIGHT_YES,
     backgroundColor = 0xFF000000,
     showBackground = true,
 )
-annotation class TabletBothModePreviews
+@Preview(
+    name = "Scaled font",
+    device = "spec:parent=pixel_tablet,orientation=portrait",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    showBackground = true,
+    fontScale = 1.5f,
+)
 annotation class PreviewTabletBothMode


### PR DESCRIPTION
#### Description

Updates the multi-preview annotations' name and adds a scaled font preview.

The updated annotations now match those in the news app which will be replaced by these.

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

