### PR TITLE
Add dokka

### DIFF
--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -1,0 +1,43 @@
+name: Android Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+
+      - name: Build and generate docs
+        run: |
+          cd android
+          ./gradlew :source:dokkaGfm --no-configuration-cache
+          mkdir -p ../docs
+          mv source/build/dokka/gfm/* ../docs/
+                    
+      - name: Commit and push changes
+        run: |
+          git checkout gh-pages
+          git add docs
+          git commit -m "Update docs" -- docs
+          git push origin gh-pages --set-upstream
+          

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -11,8 +11,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Check for Android changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          android:
+            - 'android/**'
+            - '.github/**'          
+
   build:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.android == 'true' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/android/build-logic/convention/build.gradle.kts
+++ b/android/build-logic/convention/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.detekt.gradlePlugin)
     compileOnly(libs.composeCompiler.gradlePlugin)
+    compileOnly(libs.dokka.gradlePlugin)
 
     lintChecks(libs.androidx.lint.gradle)
 }

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidLibraryConventionPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidLibraryConventionPlugin.kt
@@ -9,6 +9,7 @@ import com.theguardian.convention.shared.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 /**
  * Configures the Android library modules.
@@ -28,11 +29,16 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply(libs.plugin("agp-library").pluginId)
                 apply(libs.plugin("kgp").pluginId)
+                apply(libs.plugin("dokka").pluginId)
                 apply(libs.plugin("kotlinter").pluginId)
             }
 
             extensions.configure<LibraryExtension> {
                 configureAndroidModule(this)
+
+                dependencies {
+                    add("implementation", libs.findLibrary("dokka-android").get())
+                }
 
                 if (shouldSetupAndroidTests) {
                     configureAndroidTests(this)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.paparazzi) apply false
     alias(libs.plugins.nexus.publish)
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.dokka) apply false
 }
 
 group = libs.versions.group.get()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,6 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-# Dokka only works with this disabled
-org.gradle.configuration-cache=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -23,4 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Dokka only works with this disabled
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Dokka only works with this disabled
+org.gradle.configuration-cache=false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", ver
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 composeCompiler-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 # These rules are now maintained independently by Nacho Lopez who originally created them at
 # Twitter: https://github.com/mrmans0n/compose-rules

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+dokka-android = { module = "org.jetbrains.dokka:android-documentation-plugin", version.ref = "dokka" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "inject" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ composeBom = "2024.06.00"
 composeLint = "0.4.10"
 coreKtx = "1.13.1"
 detekt = "1.23.6"
+dokka = "1.9.20"
 inject = "1"
 kotlinx-collections-immutable = "0.3.7"
 lifecycleRuntimeKtx = "2.8.4"
@@ -92,6 +93,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kgp = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -35,6 +35,7 @@ android {
 }
 
 dependencies {
+    dokkaPlugin(libs.dokka.android)
 }
 
 publishing {

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.guardian.library.android)
     alias(libs.plugins.guardian.compose.library)
     alias(libs.plugins.guardian.detekt)
+    alias(libs.plugins.dokka)
 }
 
 android {

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -83,17 +83,6 @@ publishing {
     }
 
     repositories {
-        // This is commented out because we're using nexus publishing plugin to publish to Sonatype.
-        // That's configured in the root build.gradle.kts file.
-//        maven {
-//            name = "sonatype"
-//            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-//            credentials {
-//                username = "guardian.automated.maven.release"
-//                password = System.getenv("AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD")
-//            }
-//        }
-
         // Adds a task for publishing locally to the build directory.
         // Use as `./gradlew :source:publishReleasePublicationToGusourceRepository`
         maven {

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.guardian.library.android)
     alias(libs.plugins.guardian.compose.library)
     alias(libs.plugins.guardian.detekt)
-//    alias(libs.plugins.dokka)
 }
 
 android {
@@ -34,7 +33,8 @@ android {
     }
 }
 
-dependencies {}
+dependencies {
+}
 
 publishing {
     publications {

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.guardian.library.android)
     alias(libs.plugins.guardian.compose.library)
     alias(libs.plugins.guardian.detekt)
-    alias(libs.plugins.dokka)
+//    alias(libs.plugins.dokka)
 }
 
 android {
@@ -34,9 +34,7 @@ android {
     }
 }
 
-dependencies {
-    dokkaPlugin(libs.dokka.android)
-}
+dependencies {}
 
 publishing {
     publications {


### PR DESCRIPTION
#### Description

Adds the Gradle plugin for Dokka. Also adds a GA workflow to create the documentation pages and commit them to the `docs` folder on the `gh-pages` branch.

There will be more changes but want to get this merged so we can run and test the workflow.