### PR TITLE
Dokka 2: Fix commit issues and link from docs

### DIFF
--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -50,13 +50,15 @@ jobs:
         run: |
           cd android
           ./gradlew :source:dokkaGfm --no-configuration-cache
-          mkdir -p ../docs
-          mv source/build/dokka/gfm/* ../docs/
+          rm -rf docs
+          mkdir -p docs
+          mv source/build/dokka/gfm/* docs/
                     
       - name: Commit and push changes
         run: |
-          git checkout gh-pages
-          git add docs
+          git rev-parse --quiet --verify refs/heads/gh-pages >/dev/null && exists=true || exists=false
+          if $exists; then git checkout gh-pages; else git checkout -b gh-pages; fi
+          git add android/docs
           git commit -m "Update docs" -- docs
           git push origin gh-pages --set-upstream
           

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.android == 'true' }}
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -14,6 +14,7 @@ jobs:
   changes:
     name: Check for Android changes
     runs-on: ubuntu-latest
+    if: github.repository == 'guardian/source-apps'
     permissions:
       pull-requests: read
     outputs:
@@ -32,7 +33,7 @@ jobs:
     name: Generate Android docs
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.android == 'true' }}
+    if: ${{ needs.changes.outputs.android == 'true' && github.repository == 'guardian/source-apps' }}
     permissions: write-all
 
     steps:
@@ -51,10 +52,10 @@ jobs:
       - name: Build and generate docs
         run: |
           cd android
-          ./gradlew :source:dokkaGfm --no-configuration-cache
+          ./gradlew :source:dokkaHtml --no-configuration-cache
           rm -rf docs
           mkdir -p docs
-          mv source/build/dokka/gfm/* docs/
+          mv source/build/dokka/html/* docs/
                     
       - name: Commit and push changes
         run: |

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -47,7 +47,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-
+      
+      - name: Switch to gh-pages branch
+        run: |
+          git config --global user.name "GuardianAndroid"
+          git config --global user.email "guardian.android@gmail.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          git pull origin gh-pages
 
       - name: Build and generate docs
         run: |
@@ -59,11 +66,6 @@ jobs:
                     
       - name: Commit and push changes
         run: |
-          git config --global user.name "GuardianAndroid"
-          git config --global user.email "guardian.android@gmail.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          git pull origin gh-pages
           git add android/docs
           git commit -m "Update docs" -- android/docs
           git push origin gh-pages --set-upstream

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -28,7 +28,8 @@ jobs:
             - 'android/**'
             - '.github/**'          
 
-  build:
+  docs:
+    name: Generate Android docs
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.android == 'true' }}
@@ -56,6 +57,8 @@ jobs:
                     
       - name: Commit and push changes
         run: |
+          git config --global user.name "GuardianAndroid"
+          git config --global user.email "guardian.android@gmail.com"
           git rev-parse --quiet --verify refs/heads/gh-pages >/dev/null && exists=true || exists=false
           if $exists; then git checkout gh-pages; else git checkout -b gh-pages; fi
           git add android/docs

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -60,8 +60,9 @@ jobs:
         run: |
           git config --global user.name "GuardianAndroid"
           git config --global user.email "guardian.android@gmail.com"
-          git rev-parse --quiet --verify refs/heads/gh-pages >/dev/null && exists=true || exists=false
-          if $exists; then git checkout gh-pages; else git checkout -b gh-pages; fi
+          git fetch origin gh-pages
+          git checkout gh-pages
+          git pull origin gh-pages
           git add android/docs
           git commit -m "Update docs" -- android/docs
           git push origin gh-pages --set-upstream

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -59,6 +59,6 @@ jobs:
           git rev-parse --quiet --verify refs/heads/gh-pages >/dev/null && exists=true || exists=false
           if $exists; then git checkout gh-pages; else git checkout -b gh-pages; fi
           git add android/docs
-          git commit -m "Update docs" -- docs
+          git commit -m "Update docs" -- android/docs
           git push origin gh-pages --set-upstream
           

--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,26 +5,26 @@ on:
   release:
 
 jobs:
-  if: github.repository == 'guardian/source-apps'
   release:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
+    if: github.repository == 'guardian/source-apps'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-        - name: Set up JDK 17
-          uses: actions/setup-java@v4
-          with:
-            java-version: '17'
-            distribution: 'temurin'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-        - name: Setup Gradle
-          uses: gradle/actions/setup-gradle@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
-        - name: Release
-          env:
-            AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
-            AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}
-            AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
-          run: |
-            cd android
-            ./gradlew :source:publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Release
+        env:
+          AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+          AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
+        run: |
+          cd android
+          ./gradlew :source:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   release:
 
 jobs:
+  if: github.repository == 'guardian/source-apps'
   release:
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [Android library details and usage notes are here.](/android/README.md).
 
-[API documentation is here.](/android/docs/).
+[API documentation is here.](https://guardian.github.io/source-apps/android/docs/index.html).
 
 # iOS Usage 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 [![Available on maven central](https://maven-badges.herokuapp.com/maven-central/com.gu.source/source-android/badge.svg)](https://central.sonatype.com/artifact/com.gu.source/source-android)
 
-[Android library details and usage notes](/android/README.md).
+[Android library details and usage notes are here.](/android/README.md).
+
+[API documentation is here.](/android/docs/).
 
 # iOS Usage 
 

--- a/android/README.md
+++ b/android/README.md
@@ -47,7 +47,7 @@ Text(
 ```
 ### Core palette colours
 
-Core palette colours are available for direct use in components through `Source.Palette`. [Preview all available colours here](https://github.com/guardian/source-apps/blob/main/android/source/src/main/kotlin/com/gu/source/presets/palette/palette.png).
+Core palette colours are available for direct use in components through `Source.Palette`. [Preview all available colours here](source/src/main/kotlin/com/gu/source/presets/palette/palette.png).
 
 ```kotlin
 Text(

--- a/android/README.md
+++ b/android/README.md
@@ -28,6 +28,8 @@ The library provides design presets and components.
 
 The design presets are available name spaced under the `com.gu.Source` object, e.g. `Source.Typography.HeadlineBold15`.
 
+Full documentation is available [in docs](/android/docs/).
+
 ### Typography presets
 
 Typography presets include `fontFamily`, `fontSize`, `lineHeight`, `fontWeight`, `fontStyle` in a single token. [All typography tokens with their previews are listed here](/android/source/src/main/kotlin/com/gu/source/presets/typography/README.md)

--- a/android/README.md
+++ b/android/README.md
@@ -28,7 +28,7 @@ The library provides design presets and components.
 
 The design presets are available name spaced under the `com.gu.Source` object, e.g. `Source.Typography.HeadlineBold15`.
 
-Full documentation is available [in docs](/android/docs/).
+[API documentation is here.](/android/docs/).
 
 ### Typography presets
 

--- a/android/README.md
+++ b/android/README.md
@@ -28,7 +28,7 @@ The library provides design presets and components.
 
 The design presets are available name spaced under the `com.gu.Source` object, e.g. `Source.Typography.HeadlineBold15`.
 
-[API documentation is here.](/android/docs/).
+[API documentation is here.](https://guardian.github.io/source-apps/android/docs/index.html).
 
 ### Typography presets
 

--- a/android/README.md
+++ b/android/README.md
@@ -32,7 +32,7 @@ The design presets are available name spaced under the `com.gu.Source` object, e
 
 ### Typography presets
 
-Typography presets include `fontFamily`, `fontSize`, `lineHeight`, `fontWeight`, `fontStyle` in a single token. [All typography tokens with their previews are listed here](/android/source/src/main/kotlin/com/gu/source/presets/typography/README.md)
+Typography presets include `fontFamily`, `fontSize`, `lineHeight`, `fontWeight`, `fontStyle` in a single token. [All typography tokens with their previews are listed here](source/src/main/kotlin/com/gu/source/presets/typography/README.md)
 
 The library bundles app font files, so they are not separately required in consumer apps.
 


### PR DESCRIPTION
#### Description

* Update the android-docs workflow with correct permissions and git setup
* Publish html docs instead of GFM docs from dokka so they appear with kotlin branding
* Add links to API documentation in readme
* Make links to other README's relative

Asides:
* Update actions/checkout to v4 where it'd been forgotten
* Add repository check to release workflow