### PR TITLE
Add a narrow width device to multi preview annotation

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.3.4"
+libraryVersion = "0.3.5"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "34"

--- a/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
+++ b/android/source/src/main/kotlin/com/gu/source/utils/PreviewAnnotations.kt
@@ -20,6 +20,13 @@ import androidx.compose.ui.tooling.preview.Preview
     showBackground = true,
 )
 @Preview(
+    name = "Samsung S20 (narrow device)",
+    device = "spec:width=945px,height=2400px",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    showBackground = true,
+)
+@Preview(
     name = "Scaled font",
     device = Devices.PIXEL_7,
     uiMode = Configuration.UI_MODE_NIGHT_NO,


### PR DESCRIPTION
#### Description

We've got a few reports of UI not rendering correctly on narrow devices. This PR adds a preview for Samsung S20 (360px width viewport) so we can preview the UI on these devices while developing.

#### Testing notes/instructions:

See the preview in `MainActivity` for a narrower version.

#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

