### PR TITLE
[Live-7031] Homepage customisation showing list icons

### DIFF
--- a/android/source/src/main/kotlin/com/gu/source/Source.kt
+++ b/android/source/src/main/kotlin/com/gu/source/Source.kt
@@ -37,6 +37,9 @@ object Source {
     object Icons {
         /** Base icons without any decoration around them. */
         object Base
+
+        /** Core icons without any decoration around them. */
+        object Core
     }
 
     /** Source colour themes used by components. */

--- a/android/source/src/main/kotlin/com/gu/source/icons/core/Minus.kt
+++ b/android/source/src/main/kotlin/com/gu/source/icons/core/Minus.kt
@@ -1,0 +1,52 @@
+package com.gu.source.icons.core
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gu.source.Source
+import com.gu.source.presets.palette.Brand400
+
+val Source.Icons.Core.Minus: ImageVector
+    get() {
+        if (minus != null) {
+            return minus!!
+        }
+        minus = ImageVector.Builder(
+            name = "CoreMinus",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).apply {
+            path(
+                fill = SolidColor(Source.Palette.Brand400),
+                pathFillType = PathFillType.EvenOdd,
+            ) {
+                moveTo(1f, 10.75f)
+                verticalLineTo(13.25f)
+                horizontalLineTo(23f)
+                verticalLineTo(10.75f)
+                horizontalLineTo(1f)
+                close()
+            }
+        }.build()
+
+        return minus!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var minus: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Icon(
+        imageVector = Source.Icons.Core.Minus,
+        contentDescription = null,
+    )
+}

--- a/android/source/src/main/kotlin/com/gu/source/icons/core/Plus.kt
+++ b/android/source/src/main/kotlin/com/gu/source/icons/core/Plus.kt
@@ -1,0 +1,60 @@
+package com.gu.source.icons.core
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gu.source.Source
+import com.gu.source.presets.palette.Brand400
+
+val Source.Icons.Core.Plus: ImageVector
+    get() {
+        if (plus != null) {
+            return plus!!
+        }
+        plus = ImageVector.Builder(
+            name = "Plus",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).apply {
+            path(
+                fill = SolidColor(Source.Palette.Brand400),
+                pathFillType = PathFillType.EvenOdd,
+            ) {
+                moveTo(10.8f, 13.2f)
+                lineTo(11.225f, 23f)
+                horizontalLineTo(12.75f)
+                lineTo(13.2f, 13.2f)
+                lineTo(23f, 12.75f)
+                verticalLineTo(11.225f)
+                lineTo(13.2f, 10.8f)
+                lineTo(12.75f, 1f)
+                horizontalLineTo(11.225f)
+                lineTo(10.8f, 10.8f)
+                lineTo(1f, 11.225f)
+                verticalLineTo(12.75f)
+                lineTo(10.8f, 13.2f)
+                close()
+            }
+        }.build()
+
+        return plus!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var plus: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Icon(
+        imageVector = Source.Icons.Core.Plus,
+        contentDescription = null,
+    )
+}


### PR DESCRIPTION
#### Description
For the homepage customisation screens, there are 2 of the icons from core library figma, they should be added to source library instead of adding into main app code

**Figma**: 

- https://www.figma.com/design/b2qv2OMLoNCYnP01ipfrP7/%E2%97%88-Core-library?node-id=4220-5886&node-type=frame&t=GRu2mgNt5MwTLwl6-0
- https://www.figma.com/design/b2qv2OMLoNCYnP01ipfrP7/%E2%97%88-Core-library?node-id=4220-5886&node-type=frame&t=GRVRa0nriwVitxn1-0

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:
Previews and added screen for icons in sample app

#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Documentation updated
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
