### PR TITLE
Java version setup update for AS ladybug compatibility

### DIFF
--- a/android/build-logic/convention/build.gradle.kts
+++ b/android/build-logic/convention/build.gradle.kts
@@ -5,10 +5,8 @@ plugins {
 
 group = "com.theguardian.buildlogic"
 
-java {
-    val javaVersion = JavaVersion.toVersion(libs.versions.java.get().toInt())
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
+kotlin {
+    jvmToolchain(libs.versions.java.get().toInt())
 }
 
 dependencies {

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidApplicationConventionPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidApplicationConventionPlugin.kt
@@ -8,6 +8,7 @@ import com.theguardian.convention.shared.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 /**
  * Configures the Android application module.
@@ -33,7 +34,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     targetSdk = libs.findVersion("targetsdk").get().toString().toInt()
                 }
 
-                configureAndroidModule(this)
+                configureAndroidModule<KotlinAndroidProjectExtension>(this)
 
                 configureAndroidTests(this)
 

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidLibraryConventionPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidLibraryConventionPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 /**
  * Configures the Android library modules.
@@ -31,7 +32,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             }
 
             extensions.configure<LibraryExtension> {
-                configureAndroidModule(this)
+                configureAndroidModule<KotlinAndroidProjectExtension>(this)
 
                 if (shouldSetupAndroidTests) {
                     configureAndroidTests(this)

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidTestConventionPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/AndroidTestConventionPlugin.kt
@@ -8,6 +8,7 @@ import com.theguardian.convention.shared.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 /**
  * Configures the Android test modules.
@@ -29,7 +30,7 @@ class AndroidTestConventionPlugin : Plugin<Project> {
             }
 
             extensions.configure<TestExtension> {
-                configureAndroidModule(this)
+                configureAndroidModule<KotlinAndroidProjectExtension>(this)
 
                 configureAndroidTests(
                     extension = this,

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/KotlinLibraryConventionPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/KotlinLibraryConventionPlugin.kt
@@ -5,6 +5,7 @@ import com.theguardian.convention.shared.libs
 import com.theguardian.convention.shared.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 /**
  * Configures the Android application module.
@@ -23,7 +24,7 @@ class KotlinLibraryConventionPlugin : Plugin<Project> {
                 apply(libs.plugin("kotlinter").pluginId)
             }
 
-            addBaseDependencies()
+            addBaseDependencies<KotlinJvmProjectExtension>()
         }
     }
 }

--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/shared/BaseModuleConfig.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/shared/BaseModuleConfig.kt
@@ -1,17 +1,15 @@
 package com.theguardian.convention.shared
 
 import com.android.build.api.dsl.CommonExtension
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.kotlin.dsl.withType
+import org.gradle.kotlin.dsl.*
 import org.gradle.plugin.use.PluginDependency
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 
 /**
  * The Version Catalog.
@@ -24,24 +22,16 @@ internal fun VersionCatalog.plugin(alias: String): PluginDependency = findPlugin
 /**
  * Sets up core config for all Android modules - application and library.
  */
-internal fun Project.configureAndroidModule(
+internal inline fun <reified T : KotlinTopLevelExtension> Project.configureAndroidModule(
     extension: CommonExtension<*, *, *, *, *, *>,
 ) {
-    val javaVersion = JavaVersion.toVersion(
-        libs.findVersion("java").get().toString().toInt(),
-    )
-
     extension.apply {
         defaultConfig {
             minSdk = libs.findVersion("minsdk").get().toString().toInt()
             compileSdk = libs.findVersion("compilesdk").get().toString().toInt()
         }
-        compileOptions {
-            sourceCompatibility = javaVersion
-            targetCompatibility = javaVersion
-        }
 
-        addBaseDependencies()
+        addBaseDependencies<T>()
 
         dependencies {
             add("implementation", libs.findLibrary("other-timber").get())
@@ -52,21 +42,27 @@ internal fun Project.configureAndroidModule(
 /**
  * Adds the base dependencies that every module needs.
  */
-internal fun Project.addBaseDependencies() {
+internal inline fun <reified T : KotlinTopLevelExtension> Project.addBaseDependencies() {
     dependencies {
         add("implementation", libs.findLibrary("kotlin-stdlib").get())
         add("implementation", libs.findLibrary("javax-inject").get())
     }
-    setupKotlinCompilerOptions()
+    setupKotlinCompilerOptions<T>()
 }
 
-private fun Project.setupKotlinCompilerOptions() {
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = libs.findVersion("java").get().toString()
+private inline fun <reified T : KotlinTopLevelExtension> Project.setupKotlinCompilerOptions() =
+    configure<T> {
+        when (this) {
+            is KotlinAndroidProjectExtension -> compilerOptions
+            is KotlinJvmProjectExtension -> compilerOptions
+            else -> TODO("Unsupported project extension $this ${T::class}")
+        }.apply {
+            jvmToolchain(libs.findVersion("java").get().toString().toInt())
             val warningsAsErrors: String? by project
             allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs = freeCompilerArgs + listOf(
+            freeCompilerArgs.addAll(
+                // Suggested by Braze SDK integration guide, for further information:
+                // https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
                 "-Xjvm-default=all",
                 "-opt-in=kotlin.RequiresOptIn",
                 // Enable experimental coroutines APIs, including Flow
@@ -76,7 +72,6 @@ private fun Project.setupKotlinCompilerOptions() {
             )
         }
     }
-}
 
 internal fun Project.dokkaConfig() {
     tasks.withType<DokkaTask>().configureEach {


### PR DESCRIPTION
#### Description

AS Ladybug has changed the bundled Java version to 21. This means that java compile tasks run with 21 and kotlin compile with 17 (specified in config).

This PR updates the project to use `jvmToolChain` so java and kotlin compile tasks all use the version specified by the toolchain.

This PR does NOT update the java version.

#### Testing notes/instructions:

Build and run the sample app from AS Ladybird.

#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

