### PR TITLE
iOS - Separate out pagination button from progress bar component

### DIFF
--- a/Sources/Source/Components/Buttons/IconButton.swift
+++ b/Sources/Source/Components/Buttons/IconButton.swift
@@ -9,21 +9,21 @@ public struct IconButton: View {
     private let iconColor: Color
     private let borderColor: Color
     private let action: () -> ()
-    @Binding private var disabled: Bool
+    private var disabled: Bool
 
     public init(
         icon: Image,
         size: ButtonSize,
         iconColor: Color,
         borderColor: Color,
-        disabled: Binding<Bool> = .constant(false),
+        disabled: Bool = false,
         action: @escaping () -> Void
     ) {
         self.icon = icon
         self.size = size
         self.iconColor = iconColor
         self.borderColor = borderColor
-        self._disabled = disabled
+        self.disabled = disabled
         self.action = action
     }
 
@@ -35,7 +35,7 @@ public struct IconButton: View {
             icon
                 .resizable()
         }
-        .buttonStyle(IconButtonStyle(size: size, isDisabled: $disabled, borderColor: borderColor, iconColor: iconColor))
+        .buttonStyle(IconButtonStyle(size: size, isDisabled: disabled, borderColor: borderColor, iconColor: iconColor))
 
     }
 }
@@ -45,16 +45,16 @@ public struct IconButton: View {
 /// Custom disabled functionality has been used here, rather than the native to ensure the styling of the button in the disabled state is correctly reflected and that no touch events are passed through to the view behind.
 struct IconButtonStyle: ButtonStyle {
     let size: ButtonSize
-    @Binding private var isDisabled: Bool
+    private var isDisabled: Bool
     let borderColor: Color
     let iconColor: Color
 
     @Environment(\.colorScheme) private
     var colorScheme
 
-    init(size: ButtonSize, isDisabled: Binding<Bool> = .constant(false), borderColor: Color, iconColor: Color) {
+    init(size: ButtonSize, isDisabled: Bool = false, borderColor: Color, iconColor: Color) {
         self.size = size
-        self._isDisabled = isDisabled
+        self.isDisabled = isDisabled
         self.borderColor = borderColor
         self.iconColor = iconColor
     }
@@ -82,7 +82,7 @@ struct IconButtonStyle: ButtonStyle {
 }
 
 #Preview {
-    IconButton(icon: Image(.chevronLeft), size: .small, iconColor: .black, borderColor: .gray, disabled: .constant(false), action: {})
+    IconButton(icon: Image(.chevronLeft), size: .small, iconColor: .black, borderColor: .gray, disabled: false, action: {})
 }
 
 // Maps button size to layout values for icon.

--- a/Sources/Source/Components/Buttons/IconButton.swift
+++ b/Sources/Source/Components/Buttons/IconButton.swift
@@ -36,7 +36,6 @@ public struct IconButton: View {
                 .resizable()
         }
         .buttonStyle(IconButtonStyle(size: size, isDisabled: disabled, borderColor: borderColor, iconColor: iconColor))
-
     }
 }
 
@@ -44,10 +43,10 @@ public struct IconButton: View {
 ///
 /// Custom disabled functionality has been used here, rather than the native to ensure the styling of the button in the disabled state is correctly reflected and that no touch events are passed through to the view behind.
 struct IconButtonStyle: ButtonStyle {
-    let size: ButtonSize
-    private var isDisabled: Bool
-    let borderColor: Color
-    let iconColor: Color
+    private let size: ButtonSize
+    private let isDisabled: Bool
+    private let borderColor: Color
+    private let iconColor: Color
 
     @Environment(\.colorScheme) private
     var colorScheme

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -4,21 +4,19 @@ public struct PaginationButtons: View {
     let iconColor: Color
     let borderColor: Color
     @Binding var selectedIndex: Int
-    @Binding var canNavigateBack: Bool
-    @Binding var canNavigateForward: Bool
+    let pageCount: Int
+
 
     public init(
         iconColor: Color,
         borderColor: Color,
         selectedIndex: Binding<Int>,
-        canNavigateBack: Binding<Bool>,
-        canNavigateForward: Binding<Bool>
+        pageCount: Int
     ) {
         self.iconColor = iconColor
         self.borderColor = borderColor
         self._selectedIndex = selectedIndex
-        self._canNavigateBack = canNavigateBack
-        self._canNavigateForward = canNavigateForward
+        self.pageCount = pageCount
     }
 
     public var body: some View {
@@ -28,7 +26,7 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: $canNavigateBack
+                disabled: selectedIndex > 0
             ) {
                 withAnimation {
                     selectedIndex -= 1
@@ -39,7 +37,7 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: $canNavigateForward
+                disabled: selectedIndex < pageCount
             ) {
                 withAnimation {
                     selectedIndex += 1
@@ -50,5 +48,5 @@ public struct PaginationButtons: View {
 }
 
 #Preview {
-    PaginationButtons(iconColor: .blue, borderColor: .red, selectedIndex: .constant(0), canNavigateBack: .constant(true), canNavigateForward: .constant(false))
+    PaginationButtons(iconColor: .blue, borderColor: .red, selectedIndex: .constant(0), pageCount: 10)
 }

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -3,20 +3,30 @@ import SwiftUI
 public struct PaginationButtons: View {
     let iconColor: Color
     let borderColor: Color
-    @Binding var selectedIndex: Int
+    @Binding var selectedIndex: Int?
     let pageCount: Int
 
 
     public init(
         iconColor: Color,
         borderColor: Color,
-        selectedIndex: Binding<Int>,
+        selectedIndex: Binding<Int?>,
         pageCount: Int
     ) {
         self.iconColor = iconColor
         self.borderColor = borderColor
         self._selectedIndex = selectedIndex
         self.pageCount = pageCount
+    }
+
+    private var backDisabled: Bool {
+        guard let selectedIndex else { return true }
+        return selectedIndex > 0
+    }
+
+    private var forwardDisabled: Bool {
+        guard let selectedIndex else { return true }
+        return selectedIndex < pageCount
     }
 
     public var body: some View {
@@ -26,10 +36,12 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: selectedIndex > 0
+                disabled: backDisabled
             ) {
                 withAnimation {
-                    selectedIndex -= 1
+                    if let selectedIndex {
+                        self.selectedIndex = selectedIndex - 1
+                    }
                 }
             }
             IconButton(
@@ -37,10 +49,12 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: selectedIndex < pageCount
+                disabled: forwardDisabled
             ) {
                 withAnimation {
-                    selectedIndex += 1
+                    if let selectedIndex {
+                        self.selectedIndex = selectedIndex + 1
+                    }
                 }
             }
         }

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -6,7 +6,6 @@ public struct PaginationButtons: View {
     @Binding var selectedIndex: Int?
     let pageCount: Int
 
-
     public init(
         iconColor: Color,
         borderColor: Color,

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct PaginationButtons: View {
+    let iconColor: Color
+    let borderColor: Color
+    @Binding var selectedIndex: Int
+    @Binding var canNavigateBack: Bool
+    @Binding var canNavigateForward: Bool
+
+    var body: some View {
+        HStack {
+            IconButton(
+                icon: Image(.chevronLeft),
+                size: .small,
+                iconColor: iconColor,
+                borderColor: borderColor,
+                disabled: $canNavigateBack
+            ) {
+                withAnimation {
+                    selectedIndex -= 1
+                }
+            }
+            IconButton(
+                icon: Image(.chevronRight),
+                size: .small,
+                iconColor: iconColor,
+                borderColor: borderColor,
+                disabled: $canNavigateForward
+            ) {
+                withAnimation {
+                    selectedIndex += 1
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PaginationButtons(iconColor: .blue, borderColor: .red, selectedIndex: .constant(0), canNavigateBack: .constant(true), canNavigateForward: .constant(false))
+}

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -1,13 +1,27 @@
 import SwiftUI
 
-struct PaginationButtons: View {
+public struct PaginationButtons: View {
     let iconColor: Color
     let borderColor: Color
     @Binding var selectedIndex: Int
     @Binding var canNavigateBack: Bool
     @Binding var canNavigateForward: Bool
 
-    var body: some View {
+    public init(
+        iconColor: Color,
+        borderColor: Color,
+        selectedIndex: Binding<Int>,
+        canNavigateBack: Binding<Bool>,
+        canNavigateForward: Binding<Bool>
+    ) {
+        self.iconColor = iconColor
+        self.borderColor = borderColor
+        self._selectedIndex = selectedIndex
+        self._canNavigateBack = canNavigateBack
+        self._canNavigateForward = canNavigateForward
+    }
+
+    public var body: some View {
         HStack {
             IconButton(
                 icon: Image(.chevronLeft),

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -21,12 +21,12 @@ public struct PaginationButtons: View {
 
     private var backDisabled: Bool {
         guard let selectedIndex else { return true }
-        return selectedIndex > 0
+        return selectedIndex == 0
     }
 
     private var forwardDisabled: Bool {
         guard let selectedIndex else { return true }
-        return selectedIndex < pageCount
+        return selectedIndex >= pageCount - 1
     }
 
     public var body: some View {

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Source
 
 /// This component used to signpost progression through a paginated view.
 ///
@@ -8,7 +7,7 @@ public struct PaginationProgressBar: View {
 
     private let pageCount: Int
     private let indicatorWidth: CGFloat
-    @Binding private var selectedIndex: Int
+    @Binding private var selectedIndex: Int?
     private let primaryColor: Color
     private let secondaryColor: Color
 
@@ -22,7 +21,7 @@ public struct PaginationProgressBar: View {
     public init(
         pageCount: Int,
         indicatorWidth: CGFloat,
-        selectedIndex: Binding<Int>,
+        selectedIndex: Binding<Int?>,
         primaryColor: Color,
         secondaryColor: Color
     ) {
@@ -39,7 +38,7 @@ public struct PaginationProgressBar: View {
                 ZStack(alignment: .trailing) {
                     scrollingIndicator
                         .frame(maxWidth: .infinity, alignment: .center)
-                    PaginationButtons(iconColor: primaryColor, borderColor: secondaryColor, selectedIndex: $selectedIndex, canNavigateBack: $canNavigateBack, canNavigateForward: $canNavigateForward)
+                    PaginationButtons(iconColor: primaryColor, borderColor: secondaryColor, selectedIndex: $selectedIndex, pageCount: pageCount)
                         .frame(alignment: .trailing)
                 }
             } else {
@@ -69,7 +68,7 @@ public struct PaginationProgressBar: View {
 
 struct PaginationProgressBar_Previews_Container: PreviewProvider {
     struct Container: View {
-        @State var selectedIndex = 0
+        @State var selectedIndex: Int? = 0
         let elementArray = [0, 1, 2, 3, 4, 5, 6]
         var body: some View {
             VStack {

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -7,10 +7,10 @@ public struct PaginationProgressBar: View {
 
     private let pageCount: Int
     private let indicatorWidth: CGFloat
-    @Binding private var selectedIndex: Int?
     private let primaryColor: Color
     private let secondaryColor: Color
 
+    @Binding private var selectedIndex: Int?
     @Environment(\.horizontalSizeClass)
     private var sizeClass
 

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -39,7 +39,7 @@ public struct PaginationProgressBar: View {
                 ZStack(alignment: .trailing) {
                     scrollingIndicator
                         .frame(maxWidth: .infinity, alignment: .center)
-                    progressButtons
+                    PaginationButtons(iconColor: primaryColor, borderColor: secondaryColor, selectedIndex: $selectedIndex, canNavigateBack: $canNavigateBack, canNavigateForward: $canNavigateForward)
                         .frame(alignment: .trailing)
                 }
             } else {
@@ -59,33 +59,6 @@ public struct PaginationProgressBar: View {
             primaryColor: primaryColor,
             secondaryColor: secondaryColor
         )
-    }
-
-    private var progressButtons: some View {
-        HStack {
-            IconButton(
-                icon: Image(.chevronLeft),
-                size: .small,
-                iconColor: primaryColor,
-                borderColor: secondaryColor,
-                disabled: $canNavigateBack
-            ) {
-                withAnimation {
-                    selectedIndex -= 1
-                }
-            }
-            IconButton(
-                icon: Image(.chevronRight),
-                size: .small,
-                iconColor: primaryColor,
-                borderColor: secondaryColor,
-                disabled: $canNavigateForward
-            ) {
-                withAnimation {
-                    selectedIndex += 1
-                }
-            }
-        }
     }
 
     private func updateButtonDisabledState() {

--- a/Sources/Source/Components/ScrollingPaginationIndicator.swift
+++ b/Sources/Source/Components/ScrollingPaginationIndicator.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct ScrollingPaginationIndicator: View {
 
     private let pageCount: Int
-    @Binding private var selectedIndex: Int
+    @Binding private var selectedIndex: Int?
     private let numberOfVisibleDots: Int
     private let spacing: CGFloat
     private let indicatorWidth: CGFloat
@@ -34,7 +34,7 @@ public struct ScrollingPaginationIndicator: View {
         numberOfVisibleDots: Int = 5,
         indicatorWidth: CGFloat,
         spacing: CGFloat = 4,
-        selectedIndex: Binding<Int>,
+        selectedIndex: Binding<Int?>,
         primaryColor: Color,
         secondaryColor: Color
     ) {
@@ -56,7 +56,7 @@ public struct ScrollingPaginationIndicator: View {
     /// - Parameter index: The index of the item for which the scale factor is to be calculated.
     /// - Returns: A `CGFloat` value representing the scale factor for the item at the given index.
     private func scale(for index: Int) -> CGFloat {
-        guard pageCount >= numberOfVisibleDots else { return 1.0 }
+        guard pageCount >= numberOfVisibleDots, let selectedIndex else { return 1.0 }
         let indexDifference = abs(index - selectedIndex)
         let scaleSpread = max((CGFloat(numberOfVisibleDots - 1) / 2 + 1), 1)
         let scaleFactor = CGFloat(indexDifference) / scaleSpread
@@ -90,7 +90,7 @@ public struct ScrollingPaginationIndicator: View {
 
 struct ScrollingPageIndicator_Previews_Container: PreviewProvider {
     struct Container: View {
-        @State var selectedIndex = 0
+        @State var selectedIndex: Int? = 0
         let elementArray = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         var body: some View {
             VStack {


### PR DESCRIPTION
#### Description
As part of upcoming work on Fairground in which we want to display pagination buttons next to carousel components on tablet, this PR extracts the pagination buttons from the `PaginationProgressBar`, so that they can be used independently. 
It also does some refactoring of the logic to remove unnecessary bindings and keeps some of the `canNavigateForward` `canNavigateBack` logic internal to the buttons. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:
You can test this out by using this ios-live branch which points to this version of the `source-apps` repo - you'll need to test on tablet in order for the buttons to be displayed. 
Importantly it would be good to check that image slide shows are working as expected. If there isn't one on PROD fronts, let me know and I can help you test on CODE. 

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers


##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

![Simulator Screen Recording - iPad Pro 11-inch (M4) - 2024-10-08 at 10 12 50](https://github.com/user-attachments/assets/7f1702cc-b49f-44f3-8fd5-bb4cee686dc8)

<!-- Do not delete this ↑ blank line or the table won't work -->
