### PR TITLE
Use standard license URL

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.3.7"
+libraryVersion = "0.3.8"
 compilesdk = "34"
 minsdk = "26"
 targetsdk = "34"

--- a/android/source/build.gradle.kts
+++ b/android/source/build.gradle.kts
@@ -51,7 +51,7 @@ publishing {
                 licenses {
                     license {
                         name.set("Apache License, Version 2.0")
-                        url.set("https://github.com/guardian/source-apps/tree/main?tab=Apache-2.0-1-ov-file#readme")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
                     }
                 }
                 developers {


### PR DESCRIPTION
#### Description

Changes license url to standard public one so that we can revert https://github.com/guardian/android-feast/pull/480

The non standard license URL was causing the license task to fail.
