### PR TITLE
iOS - Refactor pager buttons forward disabled state

### DIFF
--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -4,28 +4,23 @@ public struct PaginationButtons: View {
     let iconColor: Color
     let borderColor: Color
     @Binding var selectedIndex: Int?
-    let pageCount: Int
+    let canNavigateForward: Bool
 
     public init(
         iconColor: Color,
         borderColor: Color,
         selectedIndex: Binding<Int?>,
-        pageCount: Int
+        canNavigateForward: Bool
     ) {
         self.iconColor = iconColor
         self.borderColor = borderColor
         self._selectedIndex = selectedIndex
-        self.pageCount = pageCount
+        self.canNavigateForward = canNavigateForward
     }
 
     private var backDisabled: Bool {
         guard let selectedIndex else { return true }
         return selectedIndex == 0
-    }
-
-    private var forwardDisabled: Bool {
-        guard let selectedIndex else { return true }
-        return selectedIndex >= pageCount - 1
     }
 
     public var body: some View {
@@ -48,7 +43,7 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: forwardDisabled
+                disabled: canNavigateForward
             ) {
                 withAnimation {
                     if let selectedIndex {
@@ -61,5 +56,5 @@ public struct PaginationButtons: View {
 }
 
 #Preview {
-    PaginationButtons(iconColor: .blue, borderColor: .red, selectedIndex: .constant(0), pageCount: 10)
+    PaginationButtons(iconColor: .blue, borderColor: .red, selectedIndex: .constant(0), canNavigateForward: true)
 }

--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -43,7 +43,7 @@ public struct PaginationButtons: View {
                 size: .small,
                 iconColor: iconColor,
                 borderColor: borderColor,
-                disabled: canNavigateForward
+                disabled: !canNavigateForward
             ) {
                 withAnimation {
                     if let selectedIndex {

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -32,13 +32,18 @@ public struct PaginationProgressBar: View {
         self.secondaryColor = secondaryColor
     }
 
+    private var forwardDisabled: Bool {
+        guard let selectedIndex else { return true }
+        return selectedIndex >= pageCount - 1
+    }
+
     public var body: some View {
         Group {
             if sizeClass == .regular {
                 ZStack(alignment: .trailing) {
                     scrollingIndicator
                         .frame(maxWidth: .infinity, alignment: .center)
-                    PaginationButtons(iconColor: primaryColor, borderColor: secondaryColor, selectedIndex: $selectedIndex, pageCount: pageCount)
+                    PaginationButtons(iconColor: primaryColor, borderColor: secondaryColor, selectedIndex: $selectedIndex, canNavigateForward: forwardDisabled)
                         .frame(alignment: .trailing)
                 }
             } else {


### PR DESCRIPTION
#### Description
This PR updates the `PaginationButtons` component so that it accepts a `canNavigateForward` parameter rather than `pageCount` this allows us the foward disabled state to be determined used of the component, which is especially important for carousels since the number of items to be displayed at once varies depending on the layout, eg. small carousel shows 2 items per page, whereas medium carousel shows 4 on tablet. 
The carousel component in the iOS live app can now own this logic and determine based on row and column width, whether or not the next button should be disabled. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
