### PR TITLE
Remove optionality from selected index in PaginationButtons component

### DIFF
--- a/Sources/Source/Components/PaginationButtons.swift
+++ b/Sources/Source/Components/PaginationButtons.swift
@@ -3,13 +3,13 @@ import SwiftUI
 public struct PaginationButtons: View {
     let iconColor: Color
     let borderColor: Color
-    @Binding var selectedIndex: Int?
+    @Binding var selectedIndex: Int
     let canNavigateForward: Bool
 
     public init(
         iconColor: Color,
         borderColor: Color,
-        selectedIndex: Binding<Int?>,
+        selectedIndex: Binding<Int>,
         canNavigateForward: Bool
     ) {
         self.iconColor = iconColor
@@ -19,7 +19,6 @@ public struct PaginationButtons: View {
     }
 
     private var backDisabled: Bool {
-        guard let selectedIndex else { return true }
         return selectedIndex == 0
     }
 
@@ -33,9 +32,7 @@ public struct PaginationButtons: View {
                 disabled: backDisabled
             ) {
                 withAnimation {
-                    if let selectedIndex {
-                        self.selectedIndex = selectedIndex - 1
-                    }
+                    self.selectedIndex = selectedIndex - 1
                 }
             }
             IconButton(
@@ -46,9 +43,7 @@ public struct PaginationButtons: View {
                 disabled: !canNavigateForward
             ) {
                 withAnimation {
-                    if let selectedIndex {
-                        self.selectedIndex = selectedIndex + 1
-                    }
+                    self.selectedIndex = selectedIndex + 1
                 }
             }
         }

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -10,7 +10,7 @@ public struct PaginationProgressBar: View {
     private let primaryColor: Color
     private let secondaryColor: Color
 
-    @Binding private var selectedIndex: Int?
+    @Binding private var selectedIndex: Int
     @Environment(\.horizontalSizeClass)
     private var sizeClass
 
@@ -21,7 +21,7 @@ public struct PaginationProgressBar: View {
     public init(
         pageCount: Int,
         indicatorWidth: CGFloat,
-        selectedIndex: Binding<Int?>,
+        selectedIndex: Binding<Int>,
         primaryColor: Color,
         secondaryColor: Color
     ) {
@@ -33,7 +33,6 @@ public struct PaginationProgressBar: View {
     }
 
     private var forwardEnabled: Bool {
-        guard let selectedIndex else { return false }
         return selectedIndex < pageCount - 1
     }
 
@@ -73,7 +72,7 @@ public struct PaginationProgressBar: View {
 
 struct PaginationProgressBar_Previews_Container: PreviewProvider {
     struct Container: View {
-        @State var selectedIndex: Int? = 0
+        @State var selectedIndex: Int = 0
         let elementArray = [0, 1, 2, 3, 4, 5, 6]
         var body: some View {
             VStack {

--- a/Sources/Source/Components/ScrollingPaginationIndicator.swift
+++ b/Sources/Source/Components/ScrollingPaginationIndicator.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct ScrollingPaginationIndicator: View {
 
     private let pageCount: Int
-    @Binding private var selectedIndex: Int?
+    @Binding private var selectedIndex: Int
     private let numberOfVisibleDots: Int
     private let spacing: CGFloat
     private let indicatorWidth: CGFloat
@@ -34,7 +34,7 @@ public struct ScrollingPaginationIndicator: View {
         numberOfVisibleDots: Int = 5,
         indicatorWidth: CGFloat,
         spacing: CGFloat = 4,
-        selectedIndex: Binding<Int?>,
+        selectedIndex: Binding<Int>,
         primaryColor: Color,
         secondaryColor: Color
     ) {
@@ -56,7 +56,7 @@ public struct ScrollingPaginationIndicator: View {
     /// - Parameter index: The index of the item for which the scale factor is to be calculated.
     /// - Returns: A `CGFloat` value representing the scale factor for the item at the given index.
     private func scale(for index: Int) -> CGFloat {
-        guard pageCount >= numberOfVisibleDots, let selectedIndex else { return 1.0 }
+        guard pageCount >= numberOfVisibleDots else { return 1.0 }
         let indexDifference = abs(index - selectedIndex)
         let scaleSpread = max((CGFloat(numberOfVisibleDots - 1) / 2 + 1), 1)
         let scaleFactor = CGFloat(indexDifference) / scaleSpread
@@ -90,7 +90,7 @@ public struct ScrollingPaginationIndicator: View {
 
 struct ScrollingPageIndicator_Previews_Container: PreviewProvider {
     struct Container: View {
-        @State var selectedIndex: Int? = 0
+        @State var selectedIndex: Int = 0
         let elementArray = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         var body: some View {
             VStack {


### PR DESCRIPTION
#### Description
After making `selectedIndex` used by the `PaginationButtons` component an optional Integer, we have found that the image slideshow used in the app is broken due to the `TabView` component being unable to compare the tags which are `Int` and the selected item `Int?`. 

This PR makes a change to revert this value back to a simple `Int`. There is another change in the ios-live repo which depends on this change to fix the slideshow. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
