### PR TITLE
Configure tasks lazily with `configureEach`

### DIFF
--- a/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/DetektPlugin.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/theguardian/convention/DetektPlugin.kt
@@ -31,7 +31,7 @@ class DetektPlugin : Plugin<Project> {
             }
 
             // enable reports
-            tasks.withType(Detekt::class.java) {
+            tasks.withType(Detekt::class.java).configureEach {
                 jvmTarget = JavaVersion.VERSION_17.toString()
                 reports {
                     xml.required.set(false)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -37,10 +37,10 @@ nexusPublishing {
 
 allprojects {
     // Exclude generated files from linter
-    tasks.withType<org.jmailen.gradle.kotlinter.tasks.LintTask> {
+    tasks.withType<org.jmailen.gradle.kotlinter.tasks.LintTask>().configureEach {
         source = this.source.minus(fileTree("src/build/generated")).asFileTree
     }
-    tasks.withType<FormatTask> {
+    tasks.withType<FormatTask>().configureEach {
         source = this.source.minus(fileTree("src/build/generated")).asFileTree
     }
 }


### PR DESCRIPTION
#### Description

Reduces Gradle configuration work by configuring tasks lazily.

* Use `configureEach` after `withType`

https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#:~:text=TaskCollection.whenTaskAdded(),DomainObjectCollection.configureEach()%20instead.

#### Testing notes/instructions:

Build config changes - confirm the checks pass.

#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested