### PR TITLE
Fix Source Sample app

### DIFF
--- a/SourceSample/SourceSample.xcodeproj/project.pbxproj
+++ b/SourceSample/SourceSample.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = aml.SourceSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,6 +369,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = aml.SourceSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import SwiftUI
 import GuardianFonts
 
@@ -147,3 +148,4 @@ public extension ButtonStyle where Self == SourceButtonStyle {
         .previewFonts()
     }
 }
+#endif

--- a/Sources/Source/Components/Buttons/ButtonTheme.swift
+++ b/Sources/Source/Components/Buttons/ButtonTheme.swift
@@ -1,5 +1,5 @@
 //
-
+#if os(iOS)
 import Foundation
 import SwiftUI
 
@@ -76,3 +76,4 @@ public extension ButtonTheme {
         )
     )
 }
+#endif

--- a/Sources/Source/Components/PaginationProgressBar.swift
+++ b/Sources/Source/Components/PaginationProgressBar.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-
+#if os(iOS)
 /// This component used to signpost progression through a paginated view.
 ///
 /// On tablet, buttons are provided to allow users to navigate through the pages.
@@ -99,3 +99,4 @@ struct PaginationProgressBar_Previews_Container: PreviewProvider {
         Container()
     }
 }
+#endif

--- a/Sources/Source/Components/ScrollingPaginationIndicator.swift
+++ b/Sources/Source/Components/ScrollingPaginationIndicator.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import SwiftUI
 
 /// A scrolling page indicator, inspired by Instagram's paging indicator.
@@ -133,3 +134,4 @@ fileprivate extension Int {
         return self - 1
     }
 }
+#endif


### PR DESCRIPTION
#### Description
There is a Source Sample app used to preview some of the Design system components, eg. colours. 
This a macos app and was previously not building due to some iOS specific code not compiling when building for macos. 

As a future improvement we should look at adding a check which involves building the SourceSample app. 

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested


##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
