### PR TITLE
iOS Source Buttons: don't make them `maxWidth: .infinity`, fix typo

### DIFF
--- a/Sources/Source/Components/Buttons/ButtonPriority.swift
+++ b/Sources/Source/Components/Buttons/ButtonPriority.swift
@@ -15,5 +15,5 @@ public enum ButtonPriority {
     case tertiary
 
     /// Use only in a group with a primary button for low priority actions.
-    case subdubed
+    case subdued
 }

--- a/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
@@ -14,14 +14,13 @@ public struct SourceButtonStyle: ButtonStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(maxWidth: .infinity)
+            .font(GuardianFont(style: .textSansBold, size: buttonSize.fontSize))
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .foregroundColor(foregroundColor(for: buttonPriority))
             .padding(.vertical, buttonSize.verticalPad)
             .padding(.horizontal, buttonSize.horizontalPad)
-            .font(GuardianFont(style: .textSansBold, size: buttonSize.fontSize))
-            .foregroundColor(foregroundColor(for: buttonPriority))
             .background(backgroundShape(for: buttonPriority))
             .opacity(configuration.isPressed ? 0.8 : 1)
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .lineLimit(1)
     }
 

--- a/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
@@ -32,7 +32,7 @@ public struct SourceButtonStyle: ButtonStyle {
             return Color(uiColor: buttonTheme.foregroundColorSecondary)
         case .tertiary:
             return Color(uiColor: buttonTheme.foregroundColorTertiary)
-        case .subdubed:
+        case .subdued:
             return Color(uiColor: buttonTheme.foregroundColorSubdued)
         }
     }
@@ -86,7 +86,7 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                 Button(action: {}) {
                     Text("Subdued")
                 }
-                .buttonStyle(.source(size: .medium, priority: .subdubed, theme: .brand))
+                .buttonStyle(.source(size: .medium, priority: .subdued, theme: .brand))
 
             } header: {
                 Text("Medium")
@@ -111,7 +111,7 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                 Button(action: {}) {
                     Text("Subdued")
                 }
-                .buttonStyle(.source(size: .small, priority: .subdubed, theme: .brand))
+                .buttonStyle(.source(size: .small, priority: .subdued, theme: .brand))
 
             } header: {
                 Text("Small")
@@ -136,7 +136,7 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                 Button(action: {}) {
                     Text("Subdued")
                 }
-                .buttonStyle(.source(size: .xsmall, priority: .subdubed, theme: .brand))
+                .buttonStyle(.source(size: .xsmall, priority: .subdued, theme: .brand))
 
             } header: {
                 Text("Xsmall")


### PR DESCRIPTION
#### Description

To be more in line with default button styles provided by Apple, our buttons should not have an infinite max width by default.

This PR is a dependency for [this PR](https://github.com/guardian/ios-feast/pull/414). We don't have to worry about this affecting the live app as only Feast uses these components. 