### PR TITLE
Make SubNavigation inits public

### DIFF
--- a/Sources/Source/Components/Sub Navigation/SubNavigationItemColorPalette.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItemColorPalette.swift
@@ -7,6 +7,12 @@ public struct SubNavigationItemColorPalette {
     public let textColor: Color
     public let selectedTextColor: Color
 
+    public init(selectedBackgroundColor: Color, textColor: Color, selectedTextColor: Color) {
+        self.selectedBackgroundColor = selectedBackgroundColor
+        self.textColor = textColor
+        self.selectedTextColor = selectedTextColor
+    }
+
     public static var defaultPalette: SubNavigationItemColorPalette {
         SubNavigationItemColorPalette(
             selectedBackgroundColor: Color(

--- a/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
@@ -11,6 +11,18 @@ public struct SubNavigationItemView: View {
     let isSelected: Bool
     let namespace: Namespace.ID
 
+    public init(
+        title: String,
+        palette: SubNavigationItemColorPalette = .defaultPalette,
+        isSelected: Bool,
+        namespace: Namespace.ID
+    ) {
+        self.title = title
+        self.palette = palette
+        self.isSelected = isSelected
+        self.namespace = namespace
+    }
+
     public var body: some View {
         VStack(alignment: .center) {
             Text(title)


### PR DESCRIPTION
#### Description

Follows on from https://github.com/guardian/source-apps/pull/193 , this pr makes the inits required public so that customisation of the sub nav is enabled

<!-- Do not delete this ↑ blank line or the table won't work -->