### PR TITLE
[Android] Remove Github releases as a publishing trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to Maven Central
 
 on:
   workflow_dispatch:
-  release:
+#  release:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release to Maven Central
 
 on:
   workflow_dispatch:
-#  release:
+# Do not use `release` as a trigger till we go to automated releases on PR merges.
+# Using release can have unintended consequences due to creation and editint of
+# release notes and tags all triggering the workflow.
 
 jobs:
   release:


### PR DESCRIPTION
#### Description

This PR removes Github releases as a trigger for publishing to maven central.

##### Why

We recently created Github releases for all our releases so far. This triggered several publishing flows - sometimes multiple ones for each release. The resulting flood of releases overwhelmed our Sonatype servers and has blocked the whole `com.gu` organisation from publishing any updates.

#### Testing notes/instructions:



#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

