### PR TITLE
Add Opinion.700, Sport.700 and News.700 Colors

### DIFF
--- a/SourceSample/SourceSample/Color/PaletteViewModel.swift
+++ b/SourceSample/SourceSample/Color/PaletteViewModel.swift
@@ -33,6 +33,7 @@ struct PaletteViewModel {
             ColorSwatch(color: ColorPalette.opinion500, description: "500"),
             ColorSwatch(color: ColorPalette.opinion550, description: "550"),
             ColorSwatch(color: ColorPalette.opinion600, description: "600"),
+            ColorSwatch(color: ColorPalette.opinion700, description: "700"),
             ColorSwatch(color: ColorPalette.opinion800, description: "800")
         ]),
         ColorSection(name: "Sport", colors: [

--- a/SourceSample/SourceSample/Color/PaletteViewModel.swift
+++ b/SourceSample/SourceSample/Color/PaletteViewModel.swift
@@ -23,6 +23,7 @@ struct PaletteViewModel {
             ColorSwatch(color: ColorPalette.news500, description: "500"),
             ColorSwatch(color: ColorPalette.news550, description: "550"),
             ColorSwatch(color: ColorPalette.news600, description: "600"),
+            ColorSwatch(color: ColorPalette.news700, description: "700"),
             ColorSwatch(color: ColorPalette.news800, description: "800")
         ]),
         ColorSection(name: "Opinion", colors: [
@@ -43,6 +44,7 @@ struct PaletteViewModel {
             ColorSwatch(color: ColorPalette.sport400, description: "400"),
             ColorSwatch(color: ColorPalette.sport500, description: "500"),
             ColorSwatch(color: ColorPalette.sport600, description: "600"),
+            ColorSwatch(color: ColorPalette.sport700, description: "700"),
             ColorSwatch(color: ColorPalette.sport800, description: "800")
         ]),
         ColorSection(name: "Culture", colors: [

--- a/Sources/Source/ColorPalette/ColorPalette+macos.swift
+++ b/Sources/Source/ColorPalette/ColorPalette+macos.swift
@@ -89,6 +89,7 @@ public enum ColorPalette {
     public static let opinion500 = NSColor(resource: .opinion500)
     public static let opinion550 = NSColor(resource: .opinion550)
     public static let opinion600 = NSColor(resource: .opinion600)
+    public static let opinion700 = NSColor(resource: .opinion700)
     public static let opinion800 = NSColor(resource: .opinion800)
 
     // MARK: Special Report

--- a/Sources/Source/ColorPalette/ColorPalette+macos.swift
+++ b/Sources/Source/ColorPalette/ColorPalette+macos.swift
@@ -79,6 +79,7 @@ public enum ColorPalette {
     public static let news500 = NSColor(resource: .news500)
     public static let news550 = NSColor(resource: .news550)
     public static let news600 = NSColor(resource: .news600)
+    public static let news700 = NSColor(resource: .news700)
     public static let news800 = NSColor(resource: .news800)
 
     // MARK: Opinion
@@ -116,6 +117,7 @@ public enum ColorPalette {
     public static let sport400 = NSColor(resource: .sport400)
     public static let sport500 = NSColor(resource: .sport500)
     public static let sport600 = NSColor(resource: .sport600)
+    public static let sport700 = NSColor(resource: .sport700)
     public static let sport800 = NSColor(resource: .sport800)
 
     // MARK: Success

--- a/Sources/Source/ColorPalette/ColorPalette.swift
+++ b/Sources/Source/ColorPalette/ColorPalette.swift
@@ -72,6 +72,7 @@ public enum ColorPalette {
     public static let news500 = UIColor(resource: .news500)
     public static let news550 = UIColor(resource: .news550)
     public static let news600 = UIColor(resource: .news600)
+    public static let news700 = UIColor(resource: .news700)
     public static let news800 = UIColor(resource: .news800)
 
     // MARK: Opinion
@@ -109,6 +110,7 @@ public enum ColorPalette {
     public static let sport400 = UIColor(resource: .sport400)
     public static let sport500 = UIColor(resource: .sport500)
     public static let sport600 = UIColor(resource: .sport600)
+    public static let sport700 = UIColor(resource: .sport700)
     public static let sport800 = UIColor(resource: .sport800)
 
     // MARK: Success

--- a/Sources/Source/ColorPalette/ColorPalette.swift
+++ b/Sources/Source/ColorPalette/ColorPalette.swift
@@ -82,6 +82,7 @@ public enum ColorPalette {
     public static let opinion500 = UIColor(resource: .opinion500)
     public static let opinion550 = UIColor(resource: .opinion550)
     public static let opinion600 = UIColor(resource: .opinion600)
+    public static let opinion700 = UIColor(resource: .opinion700)
     public static let opinion800 = UIColor(resource: .opinion800)
 
     // MARK: Special Report

--- a/Sources/Source/ColorPalette/Palette.xcassets/News700.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/News700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD1",
+          "green" : "0xD8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Opinion700.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Opinion700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD4",
+          "green" : "0xE7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Source/ColorPalette/Palette.xcassets/Sport700.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Sport700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xF1",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
#### Description

**Figma**: https:// (delete if not a UI PR) 

Ticket: https://github.com/guardian/design-system-advocates/issues/37
<!-- if required, **short explanation** of what the PR does (what, why and how) -->
Adds Opinion.700, Sport.700 and News.700 colors to the palette

#### Testing notes/instructions:
Confirm the new colours in the source-apps sample app

#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<img width="1013" alt="Screenshot 2025-05-09 at 10 21 38" src="https://github.com/user-attachments/assets/0b4567a7-d8b7-4549-b4e7-b5907b4640a2" />

<!-- Do not delete this ↑ blank line or the table won't work -->
