### PR TITLE
[Chore] Migrate to Sonatype central publisher portal

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -29,6 +29,9 @@ version = libs.versions.libraryVersion.get()
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+
             // Sonatype token provides username and passwords as revokable secrets combined with a
             // colon. We split them and provide it to the nexus plugin. See here for more:
             // https://github.com/guardian/gha-scala-library-release-workflow/commit/23a148a03cf71bb2093a91f047d3c368adcdf45c

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 group = "com.gu.source"
-libraryVersion = "0.8.6"
+libraryVersion = "0.8.6-rc01"
 compilesdk = "35"
 minsdk = "26"
 targetsdk = "34"


### PR DESCRIPTION
#### Description

Sonatype have [announced](https://central.sonatype.org/news/20250326_ossrh_sunset/) the End-of-Life Sunset Date for OSSRH, aka oss.sonatype.org: 30th June 2025. All users will need to migrate to the [Central Publisher Portal](https://central.sonatype.org/publish/publish-portal-guide/).

We use the gradle-nexus publishing plugin. Update to the new central publishing portal requires us to [explicitly specify the repository URLs](https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central). The default repository URLs point to OSSRH which will stop working at the end of June.

#### Testing notes/instructions:



#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested
