### PR TITLE
Update Lifestyle.800 to #FEF1F8

### DIFF
--- a/Sources/Source/ColorPalette/Palette.xcassets/Lifestyle800.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/Lifestyle800.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF7",
-          "green" : "0xEE",
+          "blue" : "0xF8",
+          "green" : "0xF1",
           "red" : "0xFE"
         }
       },


### PR DESCRIPTION
#### Description

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->
This PR updates the Lifestyle.800 color.

Requirement:
We’ve made a slight adjustment to the lifestyle.800 colour, changing it from #FEEEF7 to #FEF1F8.

This update improves the contrast against neutral.46, ensuring it meets WCAG accessibility standards for text and background colour contrast.

#### Testing notes/instructions:


#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
