### PR TITLE
Use "Gu Gradle release app" for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release
     if: github.repository == 'guardian/source-apps'
     permissions: { contents: write, pull-requests: write }
-    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@ab/only-commit-api-files-if-changed
+    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@b2bf9c33e58792d68d3338767d2f648758b6af1d
     with:
       SOURCE_DIR: 'android'
       MODULES: 'source'


### PR DESCRIPTION
#### Description

Depends on: 
1. https://github.com/guardian/github-secret-access/pull/77 and 
2. https://github.com/guardian/gha-gradle-library-release-workflow/pull/2
3. https://github.com/guardian/gha-gradle-library-release-workflow/pull/3

I'd been using the Scala release app during development of the gradle release workflow. Now that we're closer to production use, we have a Github app for Gradle release workflow: https://github.com/apps/gu-gradle-library-release

The first PR above updates Github secrets access so this repo has access to the Gradle release app's secrets.
The second PR above updates the Gradle release workflow to use the Gradle app instead of the Scala app.
With those changes in place, we now need to provide the credentials for gradle app in the release action for it to work.

The third PR above fixes a bug to correctly handle scenarios where some/all API files have not changed.

#### Testing notes/instructions:

Run a release from this branch, or see this run: https://github.com/guardian/source-apps/actions/runs/16223869474

Also see the updated comment author and icon below:

<img width="918" height="278" alt="Screenshot 2025-07-11 at 17 11 37" src="https://github.com/user-attachments/assets/10cc02c7-eceb-4e0e-a599-98fa92a52f82" />

#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

