### PR TITLE
Adds Notification Blue 400 (iOS)

### DIFF
--- a/SourceSample/SourceSample/Color/PaletteViewModel.swift
+++ b/SourceSample/SourceSample/Color/PaletteViewModel.swift
@@ -126,6 +126,9 @@ struct PaletteViewModel {
             ColorSwatch(color: ColorPalette.success300, description: "300"),
             ColorSwatch(color: ColorPalette.success400, description: "400"),
             ColorSwatch(color: ColorPalette.success500, description: "500")
+        ]),
+        ColorSection(name: "Notification Blue", colors: [
+            ColorSwatch(color: ColorPalette.notificationBlue400, description: "400")
         ])
     ]
 }

--- a/Sources/Source/ColorPalette/ColorPalette.swift
+++ b/Sources/Source/ColorPalette/ColorPalette.swift
@@ -75,6 +75,9 @@ public enum ColorPalette {
     public static let news700 = PlatformColor(resource: .news700)
     public static let news800 = PlatformColor(resource: .news800)
 
+    // MARK: Notification Blue
+    public static let notificationBlue400 = PlatformColor(resource: .notificationBlue400)
+
     // MARK: Opinion
     public static let opinion100 = PlatformColor(resource: .opinion100)
     public static let opinion200 = PlatformColor(resource: .opinion200)

--- a/Sources/Source/ColorPalette/Palette.xcassets/NotificationBlue400.colorset/Contents.json
+++ b/Sources/Source/ColorPalette/Palette.xcassets/NotificationBlue400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0x90",
+          "red" : "0x01"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
#### Description

**Figma**: https:// (delete if not a UI PR) 

<!-- if required, **short explanation** of what the PR does (what, why and how) -->
We need to add the Notification Blue 400 colors to source apps on iOS (Android done separately).

#### Testing notes/instructions:
Notification Blue colors should be at the bottom of Sourcy's Colors tab.

#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

<img width="1014" height="809" alt="Screenshot 2025-07-15 at 14 58 36" src="https://github.com/user-attachments/assets/5a4b0f47-a8ce-4670-a653-5aa8a500bc8f" />

<!-- Do not delete this ↑ blank line or the table won't work -->
