### PR TITLE
Preserve vector data for bookmark-outlined icon

### DIFF
--- a/Sources/Source/Resources/Images.xcassets/bookmark-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/bookmark-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
#### Description

On Feast we require the vector to be preserved for the bookmark outline icon, this pr is to facilitate that.

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:
None required.

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [x] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [x] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
