### PR TITLE
Enable preserve vector data for all icons

### DIFF
--- a/Sources/Source/Resources/Images.xcassets/add-to-basket.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/add-to-basket.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/alarm-clock-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/alarm-clock-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/alarm-clock-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/alarm-clock-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/alarm-clock-sounded.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/alarm-clock-sounded.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/all-recipes.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/all-recipes.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/bin.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/bin.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/book-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/book-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/bookmark-round-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/bookmark-round-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/camera-round-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/camera-round-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/camera-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/camera-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chef.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chef.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-down-single-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-down-single-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-down-single-xsmall.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-down-single-xsmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-left-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-left-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-right-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-right-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-up-and-down-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-up-and-down-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/chevron-up-single-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/chevron-up-single-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/cross-round-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/cross-round-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/cross-round-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/cross-round-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/cross-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/cross-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/crossed-out-cloud.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/crossed-out-cloud.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/cuisine.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/cuisine.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/diets.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/diets.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/discover.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/discover.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/filter-android-app.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/filter-android-app.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/filter-ios-app-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/filter-ios-app-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/filter-ios-app.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/filter-ios-app.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/filter-outlined-web.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/filter-outlined-web.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/folder-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/folder-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/folder.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/folder.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/globe.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/globe.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/google-brand.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/google-brand.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/headphones-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/headphones-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/headphones-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/headphones-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/headphones-round-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/headphones-round-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/home-house-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/home-house-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/home-square-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/home-square-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/home-square-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/home-square-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/ingredient-2.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/ingredient-2.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/ingredient-3.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/ingredient-3.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/knife-and-fork.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/knife-and-fork.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/meal-types.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/meal-types.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/message-round.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/message-round.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/message.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/message.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/newsletter-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/newsletter-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/note-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/note-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/note-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/note-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/notifications-off-round.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/notifications-off-round.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/notifications-on-round.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/notifications-on-round.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/padlock-locked.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/padlock-locked.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/padlock-unlocked.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/padlock-unlocked.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/party-popper-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/party-popper-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/party-popper-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/party-popper-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/person-round-filled.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/person-round-filled.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/person-round-outlined.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/person-round-outlined.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/pinned.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/pinned.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/plus-on-round.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/plus-on-round.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/share-app-small.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/share-app-small.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/share-app.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/share-app.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/share-round-outline.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/share-round-outline.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/shopping-basket.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/shopping-basket.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/shopping-list.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/shopping-list.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/signal-brand.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/signal-brand.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/sort.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/sort.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/star-outline.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/star-outline.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/telegram-brand.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/telegram-brand.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/text-size-round-outline.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/text-size-round-outline.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/timer.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/timer.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/twitter.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/twitter.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Source/Resources/Images.xcassets/whats-app-brand.imageset/Contents.json
+++ b/Sources/Source/Resources/Images.xcassets/whats-app-brand.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
#### Description

Enables preservation of vector data for all icons

#### Testing notes/instructions:

#### Checklist
- [x] Changes have been checked by the developer
- [x] Changes have been checked by the reviewers
- [x] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [x] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [x] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [x] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light | | |
| Dark | | |

<!-- Do not delete this ↑ blank line or the table won't work -->
