### PR TITLE
chore: Replace GuardianAndroid user with app

### DIFF
--- a/.github/workflows/android-docs.yml
+++ b/.github/workflows/android-docs.yml
@@ -37,7 +37,16 @@ jobs:
     permissions: write-all
 
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GU_ANDROID_CLIENT_ID }}
+          private-key: ${{ secrets.GU_ANDROID_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -48,12 +57,18 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Build and commit docs
         run: |
           cd android
           ./gradlew :source:dokkaGeneratePublicationHtml --no-configuration-cache --rerun-tasks --no-build-cache
-          git config --global user.name "GuardianAndroid"
-          git config --global user.email "guardian.android@gmail.com"
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git fetch origin gh-pages
           git checkout gh-pages
           git pull origin gh-pages
@@ -63,4 +78,3 @@ jobs:
           git add docs
           git diff --staged --quiet || git commit -m "Update docs" -- docs
           git push origin gh-pages --set-upstream
-          


### PR DESCRIPTION
This replaces the [GuardianAndroid user](https://github.com/orgs/guardian/people/GuardianAndroid) with a new [gu-android app](https://github.com/organizations/guardian/settings/apps/gu-android) in the [Android Docs workflow](https://github.com/guardian/source-apps/actions/workflows/android-docs.yml).

The implementation follows examples in the [create-github-app-token](https://github.com/actions/create-github-app-token) action documentation.

Tested in [several workflow runs](https://github.com/guardian/source-apps/actions/runs/17295306183) but as there aren't any docs to write yet there's still a chance it might fail in production.

See issue #246 for context.