### PR TITLE
chore: Remove GuardianAndroid from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,16 @@ jobs:
     permissions: write-all
 
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GU_ANDROID_CLIENT_ID }}
+          private-key: ${{ secrets.GU_ANDROID_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -47,7 +56,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
         with:
           gradle-version: wrapper
 
@@ -69,7 +78,7 @@ jobs:
           ./gradlew detektDebug --continue
 
       - name: Upload SARIF report for code scanning report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         if: success() || failure()
         with:
           sarif_file: android/build/reports/detekt/merge.sarif
@@ -83,6 +92,12 @@ jobs:
           cd android
           ./gradlew verifyPaparazziDebug --continue --quiet
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Create companion branch and comment content
         id: create-companion-branch
         # Don't run on merge queue branches
@@ -91,6 +106,10 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
+          # Use GitHub app as user for git commands
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+  
           # Name for companion branch
           COMPANION_BRANCH=companion/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
@@ -108,9 +127,6 @@ jobs:
           # Don't commit any other files
           git restore .
 
-          # TODO: Use Github app instead of personal access token
-          git config --global user.name GuardianAndroid
-          git config --global user.email guardian.android@gmail.com
           git commit -m "Add screenshot diff"
           git push origin HEAD:"$COMPANION_BRANCH" -f
           
@@ -134,30 +150,33 @@ jobs:
           echo "BRANCH IS ${GITHUB_REF}"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         # Don't run on merge queue branches
         if: ${{ always() && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref != 'refs/heads/main' && steps.license-check.outcome == 'success' }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           issue-number: ${{ github.event.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Screenshot tests failed
 
       - name: Add or update comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         # Don't run on merge queue branches, only run if screenshot tests failed and companion branch created
         if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')  && github.ref != 'refs/heads/main' && steps.screenshot-tests.outcome != 'success' && steps.create-companion-branch.outcome == 'success'}}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: ${{ steps.create-companion-branch.outputs.reports }}
           edit-mode: replace
 
       - name: Resolve comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         # Don't run on merge queue branches, only run if screenshot tests passed and comment exists
         if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')  && github.ref != 'refs/heads/main' && steps.screenshot-tests.outcome == 'success'  && steps.find-comment.outputs.comment-id != '' }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: |
@@ -168,6 +187,10 @@ jobs:
       - name: Cleanup outdated companion branches
         if: always()
         run: |
+          # Use GitHub app as user for git commands
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
           # Find outdated companion branches with last commit date
           git branch -r --format="%(refname:lstrip=3)" | grep companion/ | while read -r branch; do
             last_commit_date_timestamp=$(git log -1 --format=%ct "origin/$branch")


### PR DESCRIPTION
This replaces the [GuardianAndroid user](https://github.com/orgs/guardian/people/GuardianAndroid) with a new [gu-android app](https://github.com/organizations/guardian/settings/apps/gu-android) in the [Test workflow](https://github.com/guardian/source-apps/actions/workflows/test.yml).

The implementation follows examples in the [create-github-app-token](https://github.com/actions/create-github-app-token) action documentation.

Tested by [check passing](https://github.com/guardian/source-apps/actions/runs/17297237622) on this PR.
Although, as with #248, there are steps that haven't been fully tested yet but permissions look correct.

See issue #246 for context.
Closes #246.

Also pinned third-party actions to commits for safety.
