### PR TITLE
chore: Change where dependabot looks for GHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
           - "com.android.tools.lint:lint-tests"
 
   - package-ecosystem: github-actions
-    directory: /android/
+    directory: /
     schedule:
       interval: weekly
       day: sunday


### PR DESCRIPTION
This will mean dependabot looks in .github/workflows for updated GHAs, rather than under /android.

I think that in [a previous commit](https://github.com/guardian/source-apps/pull/12/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) there was an overgeneralisation and GHAs were being looked for in an unexpected place.
