### PR TITLE
Added option to hide a SubNavigationItemView

### DIFF
--- a/Sources/Source/Components/Sub Navigation/SubNavigationItem.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItem.swift
@@ -6,17 +6,20 @@ public struct SubNavigationItem {
     public let title: String
     public let palette: SubNavigationItemColorPalette
     public let didSelectItem: ((SubNavigationItem, SubNavigationItem) -> Void)?
+    public let isHidden: Bool
     @ViewBuilder public let content: () -> AnyView
 
     public init(
         title: String,
         palette: SubNavigationItemColorPalette = .defaultPalette,
         didSelectItem: ((SubNavigationItem, SubNavigationItem) -> Void)? = nil,
+        isHidden: Bool = false,
         @ViewBuilder content: @escaping () -> some View
     ) {
         self.palette = palette
         self.title = title
         self.didSelectItem = didSelectItem
+        self.isHidden = isHidden
         self.content = { AnyView(erasing: content()) }
     }
 }

--- a/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
@@ -50,22 +50,24 @@ public struct SubNavigationView: View {
                 dividerView()
                 HStack {
                     ForEach(items, id: \.title) { item in
-                        Button {
-                        } label: {
-                            SubNavigationItemView(
-                                title: item.title,
-                                palette: item.palette,
-                                isSelected: item == currentItem,
-                                namespace: namespace
+                        if item.isHidden == false {
+                            Button {
+                            } label: {
+                                SubNavigationItemView(
+                                    title: item.title,
+                                    palette: item.palette,
+                                    isSelected: item == currentItem,
+                                    namespace: namespace
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .simultaneousGesture(
+                                TapGesture().onEnded { _ in
+                                    item.didSelectItem?(currentItem, item)
+                                    currentItem = item
+                                }
                             )
                         }
-                        .buttonStyle(.plain)
-                        .simultaneousGesture(
-                            TapGesture().onEnded { _ in
-                                item.didSelectItem?(currentItem, item)
-                                currentItem = item
-                            }
-                        )
                     }
                 }
                 .padding(.horizontal, horizontalPadding)
@@ -122,6 +124,7 @@ public struct SubNavigationView: View {
         ),
         SubNavigationItem(
             title: "Test 4",
+            isHidden: false,
             content: {
                 Text("Test 4")
                     .frame(


### PR DESCRIPTION
#### Description
This pr introduces the `isHidden` variable to `SubNavigationItem` so that we can hide items via a bool value.
This is needed currently to hide the history item in MyGuardian, as it will be visible only when a feature flag is true

#### Testing notes/instructions:
In the class `SubNavigationView`, go to line 127 and change to `isHidden: true`, you should see the preview update with _Test 4_ no longer showing.

#### Checklist
- [x] Changes have been checked by the developer
- [x] Changes have been checked by the reviewers


##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->


 <img width="408" height="628" alt="Screenshot 2025-09-15 at 14 24 41" src="https://github.com/user-attachments/assets/0d466fc3-42a4-465f-a502-f269851a33ac" />


<!-- Do not delete this ↑ blank line or the table won't work -->
