### PR TITLE
[Chore] Upgrade Gradle to 8.14.3

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,8 +3,6 @@ import org.jmailen.gradle.kotlinter.tasks.FormatTask
 buildscript {
     dependencies {
         classpath(libs.other.composeLint)
-        // This is temporarily required till detekt catches up with the latest Kotlin version
-        classpath(libs.kotlin.compiler.embeddable)
     }
 }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -65,9 +65,6 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 other-timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
-# This is temporarily required till detekt catches up with the latest Kotlin version
-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
#### Description

Upgrade Gradle, remove `kotlin-compiler-embeddable`

#### Testing notes/instructions:

Checks pass.

#### Checklist
- [X] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

