### PR TITLE
Add Badge component and the "New" badge for our custom sub nav

### DIFF
--- a/Sources/Source/Badge/Badge.swift
+++ b/Sources/Source/Badge/Badge.swift
@@ -1,0 +1,112 @@
+//
+
+import SwiftUI
+import GuardianFonts
+
+struct Badge: View {
+    let text: String
+    let foregroundColor: Color
+    let backgroundColor: Color
+
+    init(
+        text: String,
+        foregroundColor: Color,
+        backgroundColor: Color
+    ) {
+        self.text = text
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+    }
+
+    @Environment(\.controlSize)
+    private var controlSize
+
+    var body: some View {
+        Text(text)
+            .font(badgeFont)
+            .padding(.horizontal, badgePadding)
+            .frame(height: badgeHeight)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor)
+            .clipShape(.rect(cornerRadius: 4))
+    }
+
+    private var badgeFont: GuardianFont {
+        switch controlSize {
+        case .mini, .small:
+            Typography.textSansBld12
+        case .regular, .large, .extraLarge:
+            Typography.textSansBld15
+        @unknown default:
+            Typography.textSansBld15
+        }
+    }
+
+    private var badgeHeight: CGFloat {
+        switch controlSize {
+        case .mini, .small: 16
+        case .regular, .large, .extraLarge: 24
+        @unknown default: 24
+        }
+    }
+
+    private var badgePadding: CGFloat {
+        switch controlSize {
+        case .mini, .small: 4
+        case .regular, .large, .extraLarge: 8
+        @unknown default: 8
+        }
+    }
+}
+
+
+#Preview {
+    Grid {
+        GridRow {
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.sport400)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral20),
+                backgroundColor: Color(ColorPalette.neutral86)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.news400)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.brand400)
+            )
+        }
+        GridRow {
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.sport400)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral20),
+                backgroundColor: Color(ColorPalette.neutral86)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.news400)
+            )
+            Badge(
+                text: "Save 30%",
+                foregroundColor: Color(ColorPalette.neutral97),
+                backgroundColor: Color(ColorPalette.brand400)
+            )
+        }
+        .controlSize(.small)
+    }
+    .previewFonts()
+}

--- a/Sources/Source/Badge/Badge.swift
+++ b/Sources/Source/Badge/Badge.swift
@@ -3,12 +3,12 @@
 import SwiftUI
 import GuardianFonts
 
-struct Badge: View {
-    let text: String
-    let foregroundColor: Color
-    let backgroundColor: Color
+public struct Badge: View {
+    public let text: String
+    public let foregroundColor: Color
+    public let backgroundColor: Color
 
-    init(
+    public init(
         text: String,
         foregroundColor: Color,
         backgroundColor: Color
@@ -21,7 +21,7 @@ struct Badge: View {
     @Environment(\.controlSize)
     private var controlSize
 
-    var body: some View {
+    public var body: some View {
         Text(text)
             .font(badgeFont)
             .padding(.horizontal, badgePadding)

--- a/Sources/Source/Components/Sub Navigation/SubNavigationItem.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItem.swift
@@ -7,6 +7,7 @@ public struct SubNavigationItem {
     public let palette: SubNavigationItemColorPalette
     public let didSelectItem: ((SubNavigationItem, SubNavigationItem) -> Void)?
     public let isHidden: Bool
+    public let isNew: Bool
     @ViewBuilder public let content: () -> AnyView
 
     public init(
@@ -14,12 +15,14 @@ public struct SubNavigationItem {
         palette: SubNavigationItemColorPalette = .defaultPalette,
         didSelectItem: ((SubNavigationItem, SubNavigationItem) -> Void)? = nil,
         isHidden: Bool = false,
+        isNew: Bool = false,
         @ViewBuilder content: @escaping () -> some View
     ) {
         self.palette = palette
         self.title = title
         self.didSelectItem = didSelectItem
         self.isHidden = isHidden
+        self.isNew = isNew
         self.content = { AnyView(erasing: content()) }
     }
 }

--- a/Sources/Source/Components/Sub Navigation/SubNavigationItemColorPalette.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItemColorPalette.swift
@@ -6,11 +6,21 @@ public struct SubNavigationItemColorPalette {
     public let selectedBackgroundColor: Color
     public let textColor: Color
     public let selectedTextColor: Color
+    public let badgeForegroundColor: Color
+    public let badgeBackgroundColor: Color
 
-    public init(selectedBackgroundColor: Color, textColor: Color, selectedTextColor: Color) {
+    public init(
+        selectedBackgroundColor: Color,
+        textColor: Color,
+        selectedTextColor: Color,
+        badgeForegroundColor: Color,
+        badgeBackgroundColor: Color,
+    ) {
         self.selectedBackgroundColor = selectedBackgroundColor
         self.textColor = textColor
         self.selectedTextColor = selectedTextColor
+        self.badgeForegroundColor = badgeForegroundColor
+        self.badgeBackgroundColor = badgeBackgroundColor
     }
 
     public static var defaultPalette: SubNavigationItemColorPalette {
@@ -32,7 +42,19 @@ public struct SubNavigationItemColorPalette {
                     light: ColorPalette.neutral97,
                     dark: ColorPalette.neutral7
                 )
-            )
+            ),
+            badgeForegroundColor: Color(
+                .dynamicColor(
+                light: ColorPalette.neutral97,
+                dark: ColorPalette.sport300
+                )
+            ),
+            badgeBackgroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.sport400,
+                    dark: ColorPalette.sport800
+                )
+            ),
         )
     }
 }

--- a/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
@@ -8,27 +8,40 @@ public struct SubNavigationItemView: View {
     let title: String
     let palette: SubNavigationItemColorPalette
     let isSelected: Bool
+    let isNew: Bool
     let namespace: Namespace.ID
 
     public init(
         title: String,
         palette: SubNavigationItemColorPalette = .defaultPalette,
         isSelected: Bool,
+        isNew: Bool,
         namespace: Namespace.ID
     ) {
         self.title = title
         self.palette = palette
         self.isSelected = isSelected
+        self.isNew = isNew
         self.namespace = namespace
     }
 
     public var body: some View {
         VStack(alignment: .center) {
-            Text(title)
-                .font(Typography.textSans14)
-                .foregroundStyle(
-                    isSelected ? palette.selectedTextColor : palette.textColor
-                )
+            HStack(spacing: 4) {
+                Text(title)
+                    .font(Typography.textSans14)
+                    .foregroundStyle(
+                        isSelected ? palette.selectedTextColor : palette.textColor
+                    )
+                if isNew {
+                    Badge(
+                        text: "New",
+                        foregroundColor: palette.badgeForegroundColor,
+                        backgroundColor: palette.badgeBackgroundColor
+                    )
+                    .controlSize(.small)
+                }
+            }
                 .frame(maxWidth: .infinity)
                 .frame(height: 36)
                 .background(.white.opacity(0.000000000001)) // Almost transparent to provide a larger hit area
@@ -45,4 +58,45 @@ public struct SubNavigationItemView: View {
         }
         .animation(.snappy, value: isSelected)
     }
+}
+
+#Preview {
+    @Previewable @Namespace var namespace1
+    @Previewable @Namespace var namespace2
+    VStack {
+        HStack {
+            SubNavigationItemView(
+                title: "Test 1",
+                palette: .defaultPalette,
+                isSelected: false,
+                isNew: false,
+                namespace: namespace1
+            )
+            SubNavigationItemView(
+                title: "Test 2",
+                palette: .defaultPalette,
+                isSelected: true,
+                isNew: false,
+                namespace: namespace1
+            )
+        }
+        HStack {
+            SubNavigationItemView(
+                title: "Test 1",
+                palette: .defaultPalette,
+                isSelected: false,
+                isNew: true,
+                namespace: namespace2
+            )
+            SubNavigationItemView(
+                title: "Test 2",
+                palette: .defaultPalette,
+                isSelected: true,
+                isNew: true,
+                namespace: namespace2
+            )
+        }
+    }
+    .padding()
+    .previewFonts()
 }

--- a/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationItemView.swift
@@ -5,11 +5,11 @@ import SwiftUI
 /// didTapOptions func to update the SubNavigationView
 
 public struct SubNavigationItemView: View {
-    let title: String
-    let palette: SubNavigationItemColorPalette
-    let isSelected: Bool
-    let isNew: Bool
-    let namespace: Namespace.ID
+    public let title: String
+    public let palette: SubNavigationItemColorPalette
+    public let isSelected: Bool
+    public let isNew: Bool
+    public let namespace: Namespace.ID
 
     public init(
         title: String,

--- a/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
@@ -7,11 +7,11 @@ public struct SubNavigationView: View {
     @Environment(\.horizontalSizeClass)
     private var horizontalSizeClass
 
-    let items: [SubNavigationItem]
-    let backgroundColor: Color
-    let dividerColor: Color
+    public let items: [SubNavigationItem]
+    public let backgroundColor: Color
+    public let dividerColor: Color
 
-    @Namespace var namespace
+    @Namespace private var namespace
     @State private var currentItem: SubNavigationItem
 
     var selectedItemContent: AnyView? {
@@ -136,5 +136,6 @@ public struct SubNavigationView: View {
             }
         )
     )
+    .previewFonts()
 }
 #endif

--- a/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
+++ b/Sources/Source/Components/Sub Navigation/SubNavigationView.swift
@@ -57,6 +57,7 @@ public struct SubNavigationView: View {
                                     title: item.title,
                                     palette: item.palette,
                                     isSelected: item == currentItem,
+                                    isNew: item.isNew,
                                     namespace: namespace
                                 )
                             }
@@ -114,6 +115,7 @@ public struct SubNavigationView: View {
         ),
         SubNavigationItem(
             title: "Test 3",
+            isNew: true,
             content: {
                 Text("Test 3")
                     .frame(
@@ -123,8 +125,8 @@ public struct SubNavigationView: View {
             }
         ),
         SubNavigationItem(
-            title: "Test 4",
-            isHidden: false,
+            title: "Test 4 (Hidden)",
+            isHidden: true,
             content: {
                 Text("Test 4")
                     .frame(


### PR DESCRIPTION
#### Description

**Figma**
[Subnav Figma Link](https://www.figma.com/design/AzlT1ayOb0mv4peLWc6Ccu/My-Guardian-2.0?node-id=11801-41144&t=eX1bVJXFIfq99coI-0)
[Badge Figma Link](https://www.figma.com/design/HYKpHfksrAD4YE8P8ukN3Q/Supporter-Revenue-Toolkit?node-id=11-3&p=f&t=ydvwVygU8lmyuEVT-0)

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:

This pull request introduces a new `Badge` component and updates the sub-navigation UI to support a "New" badge for navigation items. It also extends the colour palette for the sub nav to support badge colours and updates the relevant components to handle the new functionality.

**Other Improvements**

* Updated the preview for hidden navigation items to clarify their state in the UI. (`Sources/Source/Components/Sub Navigation/SubNavigationView.swift`)

#### Checklist
- [x] Changes have been checked by the developer
- [x] Changes have been checked by the reviewers

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [x] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [x] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [x] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| `Light` | `Dark` |
| --- | --- |
|<img width="861" height="272" alt="Screenshot 2025-10-07 at 13 05 03" src="https://github.com/user-attachments/assets/c3ed2e59-a685-4e31-b46a-72123ab6824b" />|<img width="885" height="278" alt="Screenshot 2025-10-07 at 13 05 17" src="https://github.com/user-attachments/assets/674e0727-86a5-4456-a081-6e3636893102" />|
|<img width="870" height="266" alt="Screenshot 2025-10-07 at 13 04 49" src="https://github.com/user-attachments/assets/f9e20b53-b152-4774-a78b-2b7b1e50b5ac" />|<img width="842" height="264" alt="Screenshot 2025-10-07 at 13 05 26" src="https://github.com/user-attachments/assets/b86f7fed-f6b6-4aa1-86d7-02c3dfe37481" />|

| `Badge` |
| --- |
|<img width="696" height="138" alt="Screenshot 2025-10-07 at 13 05 56" src="https://github.com/user-attachments/assets/0314c488-2914-4bfb-a0b5-863b22b2ede9" />|

<!-- Do not delete this ↑ blank line or the table won't work -->
