### PR TITLE
[SR] Update ripple for SourceTextButton

### DIFF
--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -126,9 +126,11 @@ private fun rememberRippleConfiguration(
             }
         }
 
-        else -> throw IllegalArgumentException(
-            "Unsupported priority for SourceTextButton: $priority",
-        )
+        SourceButton.Priority.PrimaryOnBlue,
+        SourceButton.Priority.SecondaryOnBlue,
+        SourceButton.Priority.PrimaryOnWhite,
+        SourceButton.Priority.SecondaryOnWhite,
+        -> AppColour.Unspecified.current
     }
 
     return remember(theme, priority) {

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
@@ -68,7 +69,10 @@ fun SourceTextButton(
     )
 
     CompositionLocalProvider(
-        value = LocalRippleConfiguration provides createRippleConfiguration(appliedTheme, priority),
+        LocalRippleConfiguration provides rememberRippleConfiguration(
+            theme = appliedTheme,
+            priority = priority,
+        ),
     ) {
         PlainSourceContentButton(
             size = size,
@@ -89,47 +93,47 @@ fun SourceTextButton(
 }
 
 @Composable
-private fun createRippleConfiguration(
+private fun rememberRippleConfiguration(
     theme: Source.Theme,
     priority: SourceButton.Priority,
-): RippleConfiguration = when (priority) {
-    SourceButton.Priority.TertiaryOnWhite -> {
-        when (theme) {
-            Source.Theme.Core -> RippleConfiguration(
-                color = AppColour(
+): RippleConfiguration {
+    val colour = when (priority) {
+        SourceButton.Priority.TertiaryOnWhite -> {
+            when (theme) {
+                Source.Theme.Core -> AppColour(
                     light = Source.Palette.Brand400.copy(alpha = 0.1f),
                     dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
-                ).current,
-            )
+                ).current
 
-            Source.Theme.ReaderRevenue -> RippleConfiguration(
-                color = AppColour(
+                Source.Theme.ReaderRevenue -> AppColour(
                     light = Source.Palette.Brand400.copy(alpha = 0.1f),
                     dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
-                ).current,
-            )
+                ).current
+            }
         }
-    }
 
-    SourceButton.Priority.TertiaryOnBlue -> {
-        when (theme) {
-            Source.Theme.Core -> RippleConfiguration(
-                color = AppColour(
+        SourceButton.Priority.TertiaryOnBlue -> {
+            when (theme) {
+                Source.Theme.Core -> AppColour(
                     light = Source.Palette.Neutral100.copy(alpha = 0.2f),
                     dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
-                ).current,
-            )
+                ).current
 
-            Source.Theme.ReaderRevenue -> RippleConfiguration(
-                color = AppColour(
+                Source.Theme.ReaderRevenue -> AppColour(
                     light = Source.Palette.BrandAlt400.copy(alpha = 0.15f),
                     dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
-                ).current,
-            )
+                ).current
+            }
         }
+
+        else -> throw IllegalArgumentException(
+            "Unsupported priority for SourceTextButton: $priority",
+        )
     }
 
-    else -> throw IllegalArgumentException("Unsupported priority for SourceTextButton: $priority")
+    return remember(theme, priority) {
+        RippleConfiguration(color = colour)
+    }
 }
 
 @Composable

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -6,18 +6,28 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
+import com.gu.source.components.buttons.SourceButton.Priority.TertiaryOnBlue
+import com.gu.source.components.buttons.SourceButton.Priority.TertiaryOnWhite
 import com.gu.source.components.theme.LocalSourceTheme
 import com.gu.source.components.theme.ReaderRevenueTheme
 import com.gu.source.components.theme.SourceCoreTheme
 import com.gu.source.daynight.AppColour
 import com.gu.source.daynight.AppColourMode
+import com.gu.source.foundation.palette.Brand400
+import com.gu.source.foundation.palette.BrandAlt200
+import com.gu.source.foundation.palette.BrandAlt400
+import com.gu.source.foundation.palette.Neutral100
 import com.gu.source.foundation.palette.Neutral38
+import com.gu.source.foundation.palette.Neutral86
 import com.gu.source.utils.PreviewPhoneBothMode
 import com.gu.source.utils.PreviewTabletBothMode
 
@@ -59,21 +69,69 @@ fun SourceTextButton(
         border = AppColour.Transparent,
     )
 
-    PlainSourceContentButton(
-        size = size,
-        onClick = onClick,
-        buttonColours = buttonColours,
-        modifier = modifier,
+    CompositionLocalProvider(
+        value = LocalRippleConfiguration provides createRippleConfiguration(appliedTheme, priority),
     ) {
-        Text(
-            text = text,
-            style = size.textButtonTextStyle,
-            overflow = TextOverflow.Ellipsis,
-            softWrap = false,
-            maxLines = 1,
-            letterSpacing = 0.sp,
-        )
+        PlainSourceContentButton(
+            size = size,
+            onClick = onClick,
+            buttonColours = buttonColours,
+            modifier = modifier,
+        ) {
+            Text(
+                text = text,
+                style = size.textButtonTextStyle,
+                overflow = TextOverflow.Ellipsis,
+                softWrap = false,
+                maxLines = 1,
+                letterSpacing = 0.sp,
+            )
+        }
     }
+}
+
+@Composable
+private fun createRippleConfiguration(
+    theme: Source.Theme,
+    priority: SourceButton.Priority
+): RippleConfiguration = when (priority) {
+    TertiaryOnWhite -> {
+        when (theme) {
+            Source.Theme.Core -> RippleConfiguration(
+                color = AppColour(
+                    light = Source.Palette.Brand400.copy(alpha = 0.1f),
+                    dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
+                ).current,
+            )
+
+            Source.Theme.ReaderRevenue -> RippleConfiguration(
+                color = AppColour(
+                    light = Source.Palette.Brand400.copy(alpha = 0.1f),
+                    dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
+                ).current,
+            )
+        }
+    }
+
+    TertiaryOnBlue -> {
+        when (theme) {
+            Source.Theme.Core -> RippleConfiguration(
+                color = AppColour(
+                    light = Source.Palette.Neutral100.copy(alpha = 0.2f),
+                    dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
+                ).current,
+            )
+
+            Source.Theme.ReaderRevenue -> RippleConfiguration(
+                color = AppColour(
+                    light = Source.Palette.BrandAlt400.copy(alpha = 0.15f),
+                    dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
+                ).current,
+            )
+        }
+    }
+
+    else -> throw IllegalArgumentException("Unsupported priority for SourceTextButton: $priority")
 }
 
 @Composable

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -97,45 +97,45 @@ private fun rememberRippleConfiguration(
     theme: Source.Theme,
     priority: SourceButton.Priority,
 ): RippleConfiguration {
-    val colour = when (priority) {
-        SourceButton.Priority.TertiaryOnWhite -> {
-            when (theme) {
-                Source.Theme.Core -> AppColour(
-                    light = Source.Palette.Brand400.copy(alpha = 0.1f),
-                    dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
-                ).current
+    val appColour = remember(theme, priority) {
+        when (priority) {
+            SourceButton.Priority.TertiaryOnWhite -> {
+                when (theme) {
+                    Source.Theme.Core -> AppColour(
+                        light = Source.Palette.Brand400.copy(alpha = 0.1f),
+                        dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
+                    )
 
-                Source.Theme.ReaderRevenue -> AppColour(
-                    light = Source.Palette.Brand400.copy(alpha = 0.1f),
-                    dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
-                ).current
+                    Source.Theme.ReaderRevenue -> AppColour(
+                        light = Source.Palette.Brand400.copy(alpha = 0.1f),
+                        dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
+                    )
+                }
             }
-        }
 
-        SourceButton.Priority.TertiaryOnBlue -> {
-            when (theme) {
-                Source.Theme.Core -> AppColour(
-                    light = Source.Palette.Neutral100.copy(alpha = 0.2f),
-                    dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
-                ).current
+            SourceButton.Priority.TertiaryOnBlue -> {
+                when (theme) {
+                    Source.Theme.Core -> AppColour(
+                        light = Source.Palette.Neutral100.copy(alpha = 0.2f),
+                        dark = Source.Palette.Neutral86.copy(alpha = 0.2f),
+                    )
 
-                Source.Theme.ReaderRevenue -> AppColour(
-                    light = Source.Palette.BrandAlt400.copy(alpha = 0.15f),
-                    dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
-                ).current
+                    Source.Theme.ReaderRevenue -> AppColour(
+                        light = Source.Palette.BrandAlt400.copy(alpha = 0.15f),
+                        dark = Source.Palette.BrandAlt200.copy(alpha = 0.15f),
+                    )
+                }
             }
-        }
 
-        SourceButton.Priority.PrimaryOnBlue,
-        SourceButton.Priority.SecondaryOnBlue,
-        SourceButton.Priority.PrimaryOnWhite,
-        SourceButton.Priority.SecondaryOnWhite,
-        -> AppColour.Unspecified.current
+            SourceButton.Priority.PrimaryOnBlue,
+            SourceButton.Priority.SecondaryOnBlue,
+            SourceButton.Priority.PrimaryOnWhite,
+            SourceButton.Priority.SecondaryOnWhite,
+            -> AppColour.Unspecified
+        }
     }
 
-    return remember(theme, priority) {
-        RippleConfiguration(color = colour)
-    }
+    return RippleConfiguration(color = appColour.current)
 }
 
 @Composable

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -15,8 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.gu.source.Source
-import com.gu.source.components.buttons.SourceButton.Priority.TertiaryOnBlue
-import com.gu.source.components.buttons.SourceButton.Priority.TertiaryOnWhite
 import com.gu.source.components.theme.LocalSourceTheme
 import com.gu.source.components.theme.ReaderRevenueTheme
 import com.gu.source.components.theme.SourceCoreTheme
@@ -95,7 +93,7 @@ private fun createRippleConfiguration(
     theme: Source.Theme,
     priority: SourceButton.Priority,
 ): RippleConfiguration = when (priority) {
-    TertiaryOnWhite -> {
+    SourceButton.Priority.TertiaryOnWhite -> {
         when (theme) {
             Source.Theme.Core -> RippleConfiguration(
                 color = AppColour(
@@ -113,7 +111,7 @@ private fun createRippleConfiguration(
         }
     }
 
-    TertiaryOnBlue -> {
+    SourceButton.Priority.TertiaryOnBlue -> {
         when (theme) {
             Source.Theme.Core -> RippleConfiguration(
                 color = AppColour(

--- a/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
+++ b/android/source/src/main/kotlin/com/gu/source/components/buttons/SourceTextButton.kt
@@ -93,7 +93,7 @@ fun SourceTextButton(
 @Composable
 private fun createRippleConfiguration(
     theme: Source.Theme,
-    priority: SourceButton.Priority
+    priority: SourceButton.Priority,
 ): RippleConfiguration = when (priority) {
     TertiaryOnWhite -> {
         when (theme) {


### PR DESCRIPTION
#### Description

**Figma**: [Figma link](https://www.figma.com/design/U6ZV2Wo9BUMGMwAjPsoUBo/IAP-Braze-update?node-id=2977-8835&m=dev)

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Notes:
- Uses [these android dev docs](https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple#change-color-alpha-ripple), I have gone for `RippleConfiguration` over `RippleTheme` as the docs talk about migrating from it
- Wraps the Source text buttons implementation block in a `CompositionLocalProvider(LocalRippleTheme provides someTheme)` and uses a function to determine which ripple configuration to apply given the buttons priority and the current app theme (core or reader revenue)

#### Testing instructions:
- Start the sample app on this branch
- Open the text button preview
- When pressed make sure the pressed colour matches the "hover colour" visually in the provided Figma link
- **It is hard to see the difference visually, however there is a change, I have verified this by changing [this](https://github.com/guardian/source-apps/pull/337/changes#diff-120abbbe3df87a5e5f8f81652b3d53242ccee7ce7cb4a086c7f4cb466c4b1923R100) to `Color.Red` and observing a red ripple, you should do this aswell confirm a ripple is actually being applied.**

#### Checklist
- [ ] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested -> N/A

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: @CameronArmstrong-1 / @dan-covill / @akemitakagi 
- [ ] Dark Mode: Code accounts for light and dark mode
- [ ] Tablet: N/A
- [ ] Accessibility (e.g. VoiceOver): N/A

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

**LIGHT**
| | Core on white lm | Core on blue lm | Reader revenue on white lm | Reader revenue on blue lm |
| --- | --- | --- | --- | --- | 
| `Before` | <img width="1080" height="2340" alt="before_core_onwhite_lm" src="https://github.com/user-attachments/assets/0e67766e-9803-422c-97ec-89a1d3e82e07" /> | <img width="1080" height="2340" alt="before_core_onblue_lm" src="https://github.com/user-attachments/assets/782eb470-fde2-4768-bcd5-0d9cdaea136a" />|<img width="1080" height="2340" alt="before_readerrevenue_onwhite_lm" src="https://github.com/user-attachments/assets/52e2e20c-a049-44e8-a443-4ba6820eccb5" /> |<img width="1080" height="2340" alt="before_readerrevenue_onblue_lm" src="https://github.com/user-attachments/assets/1f384a72-bc5e-4e55-baed-e0387a615675" /> |
| `After` | <img width="1080" height="2340" alt="after_core_onwhite_lm" src="https://github.com/user-attachments/assets/5aec1695-d71b-42cc-92f1-a283aecf3f94" /> | <img width="1080" height="2340" alt="after_core_onblue_lm" src="https://github.com/user-attachments/assets/e322f674-a4e7-43cb-94f1-46cbb5a386de" /> | <img width="1080" height="2340" alt="after_readerrevenue_onwhite_lm" src="https://github.com/user-attachments/assets/60c631a9-83c8-4b26-bbf0-cfe980e89bab" />|<img width="1080" height="2340" alt="after_readerrevenue_onblue_lm" src="https://github.com/user-attachments/assets/6819538a-78ed-4d1a-a6ae-2a78b4484a74" /> |

**DARK**
| | Core on white dm | Core on blue dm | Reader revenue on white dm | Reader revenue on blue dm |
| --- | --- | --- | --- | --- | 
| `Before` |<img width="1080" height="2340" alt="before_core_onwhite_dm" src="https://github.com/user-attachments/assets/db2677d4-65bf-4458-9b66-3440b543cd46" /> |<img width="1080" height="2340" alt="before_core_onblure_dm" src="https://github.com/user-attachments/assets/6eb3ab51-3497-453e-b622-5c407bbeb671" /> |<img width="1080" height="2340" alt="before_readaerrevenue_onwhite_dm" src="https://github.com/user-attachments/assets/39ed51d6-58fa-4027-b77e-d864990225df" /> | <img width="1080" height="2340" alt="before_readerrevenue_onblue_dm" src="https://github.com/user-attachments/assets/dd0f362e-8355-40ef-8995-e51c84b54422" />|
| `After` | <img width="1080" height="2340" alt="after_core_onwhite_dm" src="https://github.com/user-attachments/assets/8810928f-39c7-4863-bdb6-c0bd211e9603" /> | <img width="1080" height="2340" alt="after_core_onblue_dm" src="https://github.com/user-attachments/assets/c1043a6e-5a8a-41fc-844f-4d76e81baad7" />| <img width="1080" height="2340" alt="after_readerrevenue_onwhite_dm" src="https://github.com/user-attachments/assets/cd2d2839-2d9c-4dbc-bfdd-1a16b004471a" /> | <img width="1080" height="2340" alt="after_readerrevenue_onblue_dm" src="https://github.com/user-attachments/assets/962cd243-6cff-4e8b-be91-27c3f3a14d78" />|

<!-- Do not delete this ↑ blank line or the table won't work -->
