### PR TITLE
Text Button - iOS

### DIFF
--- a/SourceSample/SourceSample/Buttons/ButtonExamplesView.swift
+++ b/SourceSample/SourceSample/Buttons/ButtonExamplesView.swift
@@ -139,6 +139,37 @@ struct ButtonExamplesView: View {
                         )
                 }
                 .padding()
+
+                // Text Button App
+                HStack(spacing: 12) {
+                    Button("Text Button Medium") { }
+                        .buttonStyle(
+                            .source(
+                                size: .medium,
+                                priority: .textButton,
+                                theme: .brand
+                            )
+                        )
+
+                    Button("Text Button Small") { }
+                        .buttonStyle(
+                            .source(
+                                size: .small,
+                                priority: .textButton,
+                                theme: .brand
+                            )
+                        )
+
+                    Button("Text Button XSmall") { }
+                        .buttonStyle(
+                            .source(
+                                size: .xsmall,
+                                priority: .textButton,
+                                theme: .brand
+                            )
+                        )
+                }
+                .padding()
            }
 
             // MARK: - Icon Only Buttons

--- a/SourceSample/SourceSample/DisplayExtention.swift
+++ b/SourceSample/SourceSample/DisplayExtention.swift
@@ -24,6 +24,7 @@ extension ButtonPriority {
         case .secondary: "Secondary"
         case .tertiary: "Tertiary"
         case .subdued: "Subdued"
+        case .textButton: "Text Button App"
         }
     }
 }

--- a/Sources/Source/Components/Buttons/ButtonPriority.swift
+++ b/Sources/Source/Components/Buttons/ButtonPriority.swift
@@ -16,4 +16,7 @@ public enum ButtonPriority: CaseIterable {
 
     /// Use only in a group with a primary button for low priority actions.
     case subdued
+    
+    /// Use for text-only buttons without borders, similar to tertiary but with a pressed state styling.
+    case textButton
 }

--- a/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
@@ -21,7 +21,7 @@ public struct SourceButtonStyle: ButtonStyle {
             .foregroundColor(foregroundColor(for: buttonPriority))
             .padding(.vertical, buttonSize.verticalPad)
             .padding(.horizontal, buttonSize.horizontalPad)
-            .background(backgroundShape(for: buttonPriority))
+            .background(backgroundShape(for: buttonPriority, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.8 : 1)
             .lineLimit(1)
     }
@@ -36,24 +36,29 @@ public struct SourceButtonStyle: ButtonStyle {
             return Color(buttonTheme.foregroundColorTertiary)
         case .subdued:
             return Color(buttonTheme.foregroundColorSubdued)
+        case .textButton:
+            return Color(buttonTheme.foregroundColorTextButton)
         }
     }
 
-    private func backgroundShape(for priority: ButtonPriority) -> some View {
-        Group {
-            switch priority {
-            case .primary:
+    @ViewBuilder
+    private func backgroundShape(for priority: ButtonPriority, isPressed: Bool) -> some View {
+        switch priority {
+        case .primary:
+            Capsule()
+                .fill(Color(buttonTheme.backgroundColorPrimary))
+        case .secondary:
+            Capsule()
+                .fill(Color(buttonTheme.backgroundColorSecondary))
+        case .tertiary:
+            Capsule()
+                .stroke(Color(buttonTheme.foregroundColorTertiary))
+        case .subdued:
+            EmptyView()
+        case .textButton:
+            if isPressed {
                 Capsule()
-                    .fill(Color(buttonTheme.backgroundColorPrimary))
-            case .secondary:
-                Capsule()
-                    .fill(Color(buttonTheme.backgroundColorSecondary))
-            case .tertiary:
-                Capsule()
-                    .stroke(Color(buttonTheme.foregroundColorTertiary))
-            case .subdued:
-                EmptyView()
-
+                    .fill(Color(buttonTheme.backgroundColorTextButtonPressed).opacity(colorScheme == .dark ? 0.2 : 0.1))
             }
         }
     }
@@ -135,7 +140,11 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                     Text("Subdued")
                 }
                 .buttonStyle(.source(size: .xsmall, priority: .subdued, theme: .brand))
-
+                
+                Button(action: {}) {
+                    Text("Text Button")
+                }
+                .buttonStyle(.source(size: .xsmall, priority: .textButton, theme: .brand))
             }
         }
         .padding()

--- a/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/ButtonStyle+SourceButtonStyle.swift
@@ -94,7 +94,11 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                     Text("Subdued")
                 }
                 .buttonStyle(.source(size: .medium, priority: .subdued, theme: .brand))
-
+                
+                Button(action: {}) {
+                    Text("Text Button")
+                }
+                .buttonStyle(.source(size: .medium, priority: .textButton, theme: .brand))
             }
 
             Section("Small") {
@@ -117,7 +121,11 @@ public extension ButtonStyle where Self == SourceButtonStyle {
                     Text("Subdued")
                 }
                 .buttonStyle(.source(size: .small, priority: .subdued, theme: .brand))
-
+                
+                Button(action: {}) {
+                    Text("Text Button")
+                }
+                .buttonStyle(.source(size: .small, priority: .textButton, theme: .brand))
             }
 
             Section("XSmall") {

--- a/Sources/Source/Components/Buttons/ButtonTheme.swift
+++ b/Sources/Source/Components/Buttons/ButtonTheme.swift
@@ -27,6 +27,12 @@ public struct ButtonTheme {
     /// The foreground color for the Subdued button style. By default, this is derived from `backgroundColorPrimary`.
     public let foregroundColorSubdued: PlatformColor
 
+    /// The foreground color for the TextButton button style. By default, this is derived from `foregroundColorTertiary`.
+    public let foregroundColorTextButton: PlatformColor
+
+    /// The background color for the TextButton button style when pressed.
+    public let backgroundColorTextButtonPressed: PlatformColor
+
     /// Initializes a new instance of `ButtonTheme`.
     ///
     /// - Parameters:
@@ -38,13 +44,19 @@ public struct ButtonTheme {
     ///   from `backgroundColorPrimary` if not specified.
     ///   - foregroundColorSubdued: The foreground color for the Subdued button style, derived
     ///   from `backgroundColorPrimary` if not specified.
+    ///   - foregroundColorTextButton: The foreground color for the TextButton button style, derived
+    ///   from `foregroundColorTertiary` if not specified.
+    ///   - backgroundColorTextButtonPressed: The background color for the TextButton button style when pressed, derived
+    ///   from `backgroundColorPrimary` if not specified.
     public init(
         foregroundColorPrimary: PlatformColor,
         backgroundColorPrimary: PlatformColor,
         foregroundColorSecondary: PlatformColor,
         backgroundColorSecondary: PlatformColor,
         foregroundColorTertiary: PlatformColor? = nil,
-        foregroundColorSubdued: PlatformColor? = nil
+        foregroundColorSubdued: PlatformColor? = nil,
+        foregroundColorTextButton: PlatformColor? = nil,
+        backgroundColorTextButtonPressed: PlatformColor? = nil
     ) {
         self.foregroundColorPrimary = foregroundColorPrimary
         self.backgroundColorPrimary = backgroundColorPrimary
@@ -52,6 +64,8 @@ public struct ButtonTheme {
         self.backgroundColorSecondary = backgroundColorSecondary
         self.foregroundColorTertiary = foregroundColorTertiary ?? backgroundColorPrimary
         self.foregroundColorSubdued = foregroundColorSubdued ?? backgroundColorPrimary
+        self.foregroundColorTextButton = foregroundColorTextButton ?? (foregroundColorTertiary ?? backgroundColorPrimary)
+        self.backgroundColorTextButtonPressed = backgroundColorTextButtonPressed ?? backgroundColorPrimary
     }
 }
 
@@ -73,6 +87,14 @@ public extension ButtonTheme {
         backgroundColorSecondary: .dynamicColor(
             light: ColorPalette.brand800,
             dark: ColorPalette.brand600
+        ),
+        foregroundColorTextButton: .dynamicColor(
+            light: ColorPalette.brand400,
+            dark: ColorPalette.neutral86
+        ),
+        backgroundColorTextButtonPressed: .dynamicColor(
+            light: ColorPalette.brand400,
+            dark: ColorPalette.neutral86
         )
     )
 }


### PR DESCRIPTION
#### Description
This PR will introduce a new button type for iOS. This will have a background colour when it's pressed. The screenshots below show the pressed state.

**Figma**: https://www.figma.com/design/b2qv2OMLoNCYnP01ipfrP7/%E2%97%88-Core-library?node-id=4224-69&p=f&m=dev

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:

- Build the Sourcy app on Mac
- Go to Buttons and observe the text button

#### Checklist
- [x] Changes have been checked by the developer
- [ ] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: @CameronArmstrong-1 
- [X] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [X] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [X] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `Before` | `After` |
| --- | --- | --- |
| Light |<img width="653" height="342" alt="image" src="https://github.com/user-attachments/assets/58850404-a2cb-4173-a49f-5beadf0e82f0" />|<img width="626" height="419" alt="image" src="https://github.com/user-attachments/assets/68891112-a77e-417b-9e18-d446dbe2f733" />|
| Dark |<img width="700" height="345" alt="image" src="https://github.com/user-attachments/assets/b808f474-2b0f-4c6b-8299-a00216379eea" />|<img width="660" height="423" alt="image" src="https://github.com/user-attachments/assets/0cad1f9d-ad53-4dfe-a9b9-5cfe5d52facf" />|


<!-- Do not delete this ↑ blank line or the table won't work -->
