### PR TITLE
Spinner Button - iOS

### DIFF
--- a/SourceSample/SourceSample/Buttons/ButtonBuilderView.swift
+++ b/SourceSample/SourceSample/Buttons/ButtonBuilderView.swift
@@ -12,7 +12,7 @@ struct ButtonBuilderView: View {
     @State var buttonType: ButtonType = .regular
 
     enum ButtonType {
-        case icon, regular
+        case icon, regular, spinner
     }
 
     var body: some View {
@@ -22,6 +22,8 @@ struct ButtonBuilderView: View {
                 IconButtonBuilderView()
             case .regular:
                 StandardButtonBuilderView()
+            case .spinner:
+                SpinnerButtonBuilderView()
             }
         }
         .padding()
@@ -30,6 +32,7 @@ struct ButtonBuilderView: View {
                 Picker("Type", selection: $buttonType) {
                     Text("Standard").tag(ButtonType.regular)
                     Text("Icon").tag(ButtonType.icon)
+                    Text("Spinner").tag(ButtonType.spinner)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
@@ -146,6 +149,67 @@ struct StandardButtonBuilderView: View {
                         TextField("Title", text: $title)
                             .textFieldStyle(.roundedBorder)
                         IconPicker("Icon", selection: $icon)
+                        Picker("Size", selection: $size) {
+                            ForEach(ButtonSize.allCases, id: \.self) {  size in
+                                Text(size.displayName)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        Picker("Priority", selection: $priority) {
+                            ForEach(ButtonPriority.allCases, id: \.self) {  priority in
+                                Text(priority.displayName)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    .padding()
+                    .frame(maxWidth: 600)
+                }
+
+                GroupBox("Button Theme") {
+                    ButtonThemeBuilderView(theme: $theme)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .frame(maxWidth: 600)
+                }
+            }
+        }
+    }
+}
+
+struct SpinnerButtonBuilderView: View {
+    @State var title: String = "Submit"
+    @State var state: SpinnerButtonState = .loading
+    @State var size: ButtonSize = .medium
+    @State var priority: ButtonPriority = .primary
+    @State var theme: ButtonTheme = .brand
+
+    var body: some View {
+        VStack {
+            SpinnerButton(
+                title: title,
+                state: state,
+                size: size,
+                priority: priority,
+                theme: theme,
+                action: {}
+            )
+            .frame(
+                maxWidth: .infinity,
+                minHeight: 200,
+                maxHeight: .infinity
+            )
+
+            GroupBox {
+                GroupBox("Button Config") {
+                    VStack(alignment: .leading) {
+                        TextField("Title", text: $title)
+                            .textFieldStyle(.roundedBorder)
+                        Picker("State", selection: $state) {
+                            Text("Idle").tag(SpinnerButtonState.idle)
+                            Text("Loading").tag(SpinnerButtonState.loading)
+                        }
+                        .pickerStyle(.segmented)
                         Picker("Size", selection: $size) {
                             ForEach(ButtonSize.allCases, id: \.self) {  size in
                                 Text(size.displayName)

--- a/Sources/Source/Components/Buttons/SpinnerButton.swift
+++ b/Sources/Source/Components/Buttons/SpinnerButton.swift
@@ -1,0 +1,118 @@
+//
+
+import SwiftUI
+import GuardianFonts
+
+public enum SpinnerButtonState {
+    case idle
+    case loading
+}
+
+public struct SpinnerButton: View {
+    let title: String
+    let state: SpinnerButtonState
+    let size: ButtonSize
+    let priority: ButtonPriority
+    let theme: ButtonTheme
+    let action: () -> Void
+    
+    @Environment(\.colorScheme) private var colorScheme
+    
+    public init(
+        title: String,
+        state: SpinnerButtonState = .idle,
+        size: ButtonSize,
+        priority: ButtonPriority,
+        theme: ButtonTheme,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.state = state
+        self.size = size
+        self.priority = priority
+        self.theme = theme
+        self.action = action
+    }
+    
+    public var body: some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: 8) {
+                Spacer(minLength: 0)
+                
+                if state == .loading {
+                    GuardianSpinner(
+                        size: size.spinnerSize,
+                        theme: theme,
+                        priority: priority,
+                        lineWidth: size.spinnerLineWidth
+                    )
+                }
+                
+                Text(title)
+                    
+                Spacer(minLength: 0)
+                
+                if state == .loading {
+                    Color.clear
+                        .frame(width: size.spinnerSize, height: 0)
+                }
+            }
+            .frame(height: size.spinnerSize, alignment: .center)
+        }
+        .buttonStyle(
+            .source(
+                size: size,
+                priority: priority,
+                theme: theme
+            )
+        )
+        .disabled(state == .loading)
+    }
+}
+
+extension ButtonSize {
+    var spinnerSize: CGFloat {
+        switch self {
+        case .medium:
+            return 24
+        case .small:
+            return 16
+        case .xsmall:
+            return 14
+        }
+    }
+    
+    var spinnerLineWidth: CGFloat {
+        switch self {
+        case .medium:
+            return 4
+        case .small:
+            return 2
+        case .xsmall:
+            return 1.5
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        SpinnerButton(
+            title: "Submit",
+            state: .idle,
+            size: .medium,
+            priority: .primary,
+            theme: .brand,
+            action: {}
+        )
+        
+        SpinnerButton(
+            title: "Submit",
+            state: .loading,
+            size: .medium,
+            priority: .primary,
+            theme: .brand,
+            action: {}
+        )
+    }
+    .padding()
+}

--- a/Sources/Source/Components/Buttons/SpinnerButton.swift
+++ b/Sources/Source/Components/Buttons/SpinnerButton.swift
@@ -46,6 +46,8 @@ public struct SpinnerButton: View {
                         priority: priority,
                         lineWidth: size.spinnerLineWidth
                     )
+                    .padding(.vertical, -size.verticalPad)
+                    .padding(.top, 10)
                 }
                 
                 Text(title)
@@ -57,7 +59,6 @@ public struct SpinnerButton: View {
                         .frame(width: size.spinnerSize, height: 0)
                 }
             }
-            .frame(height: size.spinnerSize, alignment: .center)
         }
         .buttonStyle(
             .source(

--- a/Sources/Source/Components/Buttons/SpinnerButton.swift
+++ b/Sources/Source/Components/Buttons/SpinnerButton.swift
@@ -46,11 +46,11 @@ public struct SpinnerButton: View {
                         priority: priority,
                         lineWidth: size.spinnerLineWidth
                     )
-                    .padding(.vertical, -size.verticalPad)
-                    .padding(.top, 10)
+                    .padding(.vertical, size.spinnerVerticalPad)
                 }
                 
                 Text(title)
+                    .padding(.vertical, size.verticalPad)
                     
                 Spacer(minLength: 0)
                 
@@ -61,10 +61,11 @@ public struct SpinnerButton: View {
             }
         }
         .buttonStyle(
-            .source(
+            SpinnerButtonStyle(
                 size: size,
                 priority: priority,
-                theme: theme
+                theme: theme,
+                isLoading: state == .loading
             )
         )
         .disabled(state == .loading)
@@ -92,6 +93,10 @@ extension ButtonSize {
         case .xsmall:
             return 1.5
         }
+    }
+    
+    var spinnerVerticalPad: CGFloat {
+        return 10
     }
 }
 

--- a/Sources/Source/Components/Buttons/SpinnerButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/SpinnerButtonStyle.swift
@@ -1,0 +1,71 @@
+//
+
+
+import SwiftUI
+import GuardianFonts
+
+/// Custom button style for spinner buttons.
+///
+/// Applies consistent styling across all spinner button states and sizes.
+public struct SpinnerButtonStyle: ButtonStyle {
+    private let buttonSize: ButtonSize
+    private let buttonPriority: ButtonPriority
+    private let buttonTheme: ButtonTheme
+    private let isLoading: Bool
+    
+    @Environment(\.colorScheme) private var colorScheme
+    
+    public init(
+        size: ButtonSize,
+        priority: ButtonPriority,
+        theme: ButtonTheme,
+        isLoading: Bool = false
+    ) {
+        self.buttonSize = size
+        self.buttonPriority = priority
+        self.buttonTheme = theme
+        self.isLoading = isLoading
+    }
+    
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(GuardianFont(style: .textSansBold, size: buttonSize.fontSize))
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .foregroundColor(foregroundColor(for: buttonPriority))
+            .padding(.horizontal, buttonSize.horizontalPad)
+            .background(backgroundShape(for: buttonPriority))
+            .opacity(configuration.isPressed ? 0.8 : 1)
+            .lineLimit(1)
+    }
+    
+    private func backgroundShape(for priority: ButtonPriority) -> some View {
+        Group {
+            switch priority {
+            case .primary:
+                Capsule()
+                    .fill(Color(buttonTheme.backgroundColorPrimary))
+            case .secondary:
+                Capsule()
+                    .fill(Color(buttonTheme.backgroundColorSecondary))
+            case .tertiary:
+                Capsule()
+                    .stroke(Color(buttonTheme.foregroundColorTertiary))
+            case .subdued:
+                EmptyView()
+            }
+        }
+    }
+    
+    private func foregroundColor(for priority: ButtonPriority) -> Color {
+        switch priority {
+        case .primary:
+            return Color(buttonTheme.foregroundColorPrimary)
+        case .secondary:
+            return Color(buttonTheme.foregroundColorSecondary)
+        case .tertiary:
+            return Color(buttonTheme.foregroundColorTertiary)
+        case .subdued:
+            return Color(buttonTheme.foregroundColorSubdued)
+        }
+    }
+}

--- a/Sources/Source/Components/Buttons/SpinnerButtonStyle.swift
+++ b/Sources/Source/Components/Buttons/SpinnerButtonStyle.swift
@@ -33,27 +33,9 @@ public struct SpinnerButtonStyle: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .foregroundColor(foregroundColor(for: buttonPriority))
             .padding(.horizontal, buttonSize.horizontalPad)
-            .background(backgroundShape(for: buttonPriority))
+            .background(backgroundShape(for: buttonPriority, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.8 : 1)
             .lineLimit(1)
-    }
-    
-    private func backgroundShape(for priority: ButtonPriority) -> some View {
-        Group {
-            switch priority {
-            case .primary:
-                Capsule()
-                    .fill(Color(buttonTheme.backgroundColorPrimary))
-            case .secondary:
-                Capsule()
-                    .fill(Color(buttonTheme.backgroundColorSecondary))
-            case .tertiary:
-                Capsule()
-                    .stroke(Color(buttonTheme.foregroundColorTertiary))
-            case .subdued:
-                EmptyView()
-            }
-        }
     }
     
     private func foregroundColor(for priority: ButtonPriority) -> Color {
@@ -66,6 +48,30 @@ public struct SpinnerButtonStyle: ButtonStyle {
             return Color(buttonTheme.foregroundColorTertiary)
         case .subdued:
             return Color(buttonTheme.foregroundColorSubdued)
+        case .textButton:
+            return Color(buttonTheme.foregroundColorTextButton)
+        }
+    }
+    
+    @ViewBuilder
+    private func backgroundShape(for priority: ButtonPriority, isPressed: Bool) -> some View {
+        switch priority {
+        case .primary:
+            Capsule()
+                .fill(Color(buttonTheme.backgroundColorPrimary))
+        case .secondary:
+            Capsule()
+                .fill(Color(buttonTheme.backgroundColorSecondary))
+        case .tertiary:
+            Capsule()
+                .stroke(Color(buttonTheme.foregroundColorTertiary))
+        case .subdued:
+            EmptyView()
+        case .textButton:
+            if isPressed {
+                Capsule()
+                    .fill(Color(buttonTheme.backgroundColorTextButtonPressed).opacity(colorScheme == .dark ? 0.2 : 0.1))
+            }
         }
     }
 }

--- a/Sources/Source/Resources/GuardianSpinner.swift
+++ b/Sources/Source/Resources/GuardianSpinner.swift
@@ -92,6 +92,8 @@ struct GuardianSpinner: View {
             return Color(theme.foregroundColorTertiary)
         case .subdued:
             return Color(theme.foregroundColorSubdued)
+        case .textButton:
+            return Color(theme.foregroundColorTertiary)
         }
     }
 }

--- a/Sources/Source/Resources/GuardianSpinner.swift
+++ b/Sources/Source/Resources/GuardianSpinner.swift
@@ -1,0 +1,102 @@
+//
+
+import SwiftUI
+
+struct GuardianSpinner: View {
+    var size: CGFloat = 22
+    var theme: ButtonTheme = .brand
+    var priority: ButtonPriority = .primary
+    var lineWidth: CGFloat = 4
+    var duration: Double = 2.75
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, canvasSize in
+                let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+                let radius = min(canvasSize.width, canvasSize.height) / 2 - lineWidth / 2
+
+                let date = timeline.date.timeIntervalSinceReferenceDate
+                let cycleTime = date.truncatingRemainder(dividingBy: duration)
+                let cycleProgress = cycleTime / duration
+
+                // Simulate strokeStart and strokeEnd (0 to 1)
+                let strokeStart: Double
+                let strokeEnd: Double
+                
+                if cycleProgress < 0.5 {
+                    // First half: arc grows to full circle
+                    let t = cycleProgress * 2
+                    strokeStart = 0
+                    strokeEnd = t
+                } else {
+                    // Second half: arc shrinks
+                    let t = (cycleProgress - 0.5) * 2
+                    strokeStart = t
+                    strokeEnd = 1
+                }
+                
+                // Add rotation
+                let rotation = cycleProgress * 360
+                
+                // Convert stroke values to angles
+                let startAngle = -90 + rotation + (strokeStart * 360)
+                let endAngle = -90 + rotation + (strokeEnd * 360)
+
+                // Background circle with secondary color at 0.1 opacity
+                let backgroundPath = Path { path in
+                    path.addArc(
+                        center: center,
+                        radius: radius,
+                        startAngle: .degrees(0),
+                        endAngle: .degrees(360),
+                        clockwise: false
+                    )
+                }
+
+                context.stroke(
+                    backgroundPath,
+                    with: .color(foregroundColor(for: priority).opacity(0.1)),
+                    lineWidth: lineWidth
+                )
+
+                // Rotating arc segment
+                if endAngle > startAngle {
+                    let chasingPath = Path { path in
+                        path.addArc(
+                            center: center,
+                            radius: radius,
+                            startAngle: .degrees(startAngle),
+                            endAngle: .degrees(endAngle),
+                            clockwise: false
+                        )
+                    }
+
+                    context.stroke(
+                        chasingPath,
+                        with: .color(foregroundColor(for: priority)),
+                        lineWidth: lineWidth
+                    )
+                }
+            }
+        }
+        .frame(width: size, height: size)
+    }
+    
+    private func foregroundColor(for priority: ButtonPriority) -> Color {
+        switch priority {
+        case .primary:
+            return Color(theme.foregroundColorPrimary)
+        case .secondary:
+            return Color(theme.foregroundColorSecondary)
+        case .tertiary:
+            return Color(theme.foregroundColorTertiary)
+        case .subdued:
+            return Color(theme.foregroundColorSubdued)
+        }
+    }
+}
+
+#Preview {
+    GuardianSpinner(size: 48, theme: .brand, lineWidth: 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+}


### PR DESCRIPTION
#### Description
This will introduce a new button type with a spinner which will include a disabled state when it's loading.

**Figma**: https://www.figma.com/design/U6ZV2Wo9BUMGMwAjPsoUBo/IAP-Braze-update?node-id=1-29&p=f&m=dev

<!-- if required, **short explanation** of what the PR does (what, why and how) -->

#### Testing notes/instructions:

- Build the Sourcy app on Mac
- Go to Button Builder and select Spinner at the top right

#### Checklist
- [X] Changes have been checked by the developer
- [x] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewiers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

##### Specific notes/instructions for the reviewer: <!-- Delete if not applicable -->

#### For pull requests introducing UI changes:

- [x] Sign-off by Design: @CameronArmstrong-1 
- [X] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [X] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [X] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

| | `After` |
| --- | --- |
| Light | <video src="https://github.com/user-attachments/assets/27dc85ec-6b8b-42ed-bffb-2140f928c9e7"></video> |
| Dark | <video src="https://github.com/user-attachments/assets/0ecf268d-f517-403a-ae9c-dc7f14321ab3"></video> |









<!-- Do not delete this ↑ blank line or the table won't work -->
