### PR TITLE
Implement Promo Sticker for iOS

### DIFF
--- a/SourceSample/SourceSample/Components/ComponentsView.swift
+++ b/SourceSample/SourceSample/Components/ComponentsView.swift
@@ -13,6 +13,9 @@ struct ComponentsView: View {
             Section("Star Rating") {
                 StarRatingBuilderView()
             }
+            Section("Promo Sticker") {
+                PromoStickerBuilderView()
+            }
         }
     }
 }

--- a/SourceSample/SourceSample/Components/Promo Sticker/PromoStickerBuilderView.swift
+++ b/SourceSample/SourceSample/Components/Promo Sticker/PromoStickerBuilderView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import Source
+
+struct PromoStickerBuilderView: View {
+
+    // Wrapper so we can select a `PromoStickerTheme` (which is a struct)
+    // from a `Picker` and iterate over the available options.
+    private enum StickerTheme: String, CaseIterable, Identifiable {
+        case red, purple, blue, green
+        var id: Self { self }
+
+        var title: String { rawValue.capitalized }
+
+        var theme: PromoStickerTheme {
+            switch self {
+            case .red: .red
+            case .purple: .purple
+            case .blue: .blue
+            case .green: .green
+            }
+        }
+    }
+
+    private enum StickerSize: String, CaseIterable, Identifiable {
+        case small, large
+        var id: Self { self }
+
+        var title: String { rawValue.capitalized }
+
+        var size: PromoStickerSize {
+            switch self {
+            case .small: .small
+            case .large: .large
+            }
+        }
+    }
+
+    private enum StickerAlignment: String, CaseIterable, Identifiable {
+        case topLeading, topTrailing, bottomLeading, bottomTrailing
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .topLeading: "Top Leading"
+            case .topTrailing: "Top Trailing"
+            case .bottomLeading: "Bottom Leading"
+            case .bottomTrailing: "Bottom Trailing"
+            }
+        }
+
+        var placement: CornerPlacement {
+            switch self {
+            case .topLeading: .topLeading
+            case .topTrailing: .topTrailing
+            case .bottomLeading: .bottomLeading
+            case .bottomTrailing: .bottomTrailing
+            }
+        }
+
+        var overlayAlignment: Alignment {
+            switch self {
+            case .topLeading: .topLeading
+            case .topTrailing: .topTrailing
+            case .bottomLeading: .bottomLeading
+            case .bottomTrailing: .bottomTrailing
+            }
+        }
+    }
+
+    @State private var text: String = "Save 30%"
+    @State private var theme: StickerTheme = .red
+    @State private var size: StickerSize = .small
+    @State private var showInCard: Bool = false
+    @State private var alignment: StickerAlignment = .topLeading
+
+    var body: some View {
+        VStack(spacing: 24) {
+            preview
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 12) {
+                    TextField("Text", text: $text)
+                        .textFieldStyle(.roundedBorder)
+
+                    themePicker
+                    sizePicker
+
+                    Toggle("Show in card", isOn: $showInCard.animation())
+
+                    if showInCard {
+                        alignmentPicker
+                    }
+                }
+                .padding()
+            }
+        }
+        .frame(maxWidth: 400)
+        .padding()
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if showInCard {
+            card
+        } else {
+            PromoStickerView(
+                text: text,
+                size: size.size,
+                theme: theme.theme
+            )
+            .frame(height: 220)
+        }
+    }
+
+    private var card: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .strokeBorder(lineWidth: 1)
+            .frame(width: 200, height: 220)
+            .foregroundColor(.secondary)
+            .overlay(alignment: alignment.overlayAlignment) {
+                PromoStickerView(
+                    text: text,
+                    size: size.size,
+                    theme: theme.theme,
+                    alignment: alignment.placement
+                )
+            }
+    }
+
+    private var themePicker: some View {
+        Picker("Theme", selection: $theme) {
+            ForEach(StickerTheme.allCases) { theme in
+                Text(theme.title).tag(theme)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var sizePicker: some View {
+        Picker("Size", selection: $size) {
+            ForEach(StickerSize.allCases) { size in
+                Text(size.title).tag(size)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var alignmentPicker: some View {
+        Picker("Alignment", selection: $alignment) {
+            ForEach(StickerAlignment.allCases) { alignment in
+                Text(alignment.title).tag(alignment)
+            }
+        }
+        .pickerStyle(.menu)
+    }
+}
+
+#Preview {
+    PromoStickerBuilderView()
+}

--- a/SourceSample/SourceSample/Components/Promo Sticker/PromoStickerBuilderView.swift
+++ b/SourceSample/SourceSample/Components/Promo Sticker/PromoStickerBuilderView.swift
@@ -3,8 +3,6 @@ import Source
 
 struct PromoStickerBuilderView: View {
 
-    // Wrapper so we can select a `PromoStickerTheme` (which is a struct)
-    // from a `Picker` and iterate over the available options.
     private enum StickerTheme: String, CaseIterable, Identifiable {
         case red, purple, blue, green
         var id: Self { self }
@@ -85,7 +83,7 @@ struct PromoStickerBuilderView: View {
                     themePicker
                     sizePicker
 
-                    Toggle("Show in card", isOn: $showInCard.animation())
+                    Toggle("Show in card", isOn: $showInCard)
 
                     if showInCard {
                         alignmentPicker
@@ -130,7 +128,8 @@ struct PromoStickerBuilderView: View {
     private var themePicker: some View {
         Picker("Theme", selection: $theme) {
             ForEach(StickerTheme.allCases) { theme in
-                Text(theme.title).tag(theme)
+                Text(theme.title)
+                    .tag(theme)
             }
         }
         .pickerStyle(.segmented)
@@ -139,7 +138,8 @@ struct PromoStickerBuilderView: View {
     private var sizePicker: some View {
         Picker("Size", selection: $size) {
             ForEach(StickerSize.allCases) { size in
-                Text(size.title).tag(size)
+                Text(size.title)
+                    .tag(size)
             }
         }
         .pickerStyle(.segmented)
@@ -148,10 +148,11 @@ struct PromoStickerBuilderView: View {
     private var alignmentPicker: some View {
         Picker("Alignment", selection: $alignment) {
             ForEach(StickerAlignment.allCases) { alignment in
-                Text(alignment.title).tag(alignment)
+                Text(alignment.title)
+                    .tag(alignment)
             }
         }
-        .pickerStyle(.menu)
+        .pickerStyle(.automatic)
     }
 }
 

--- a/Sources/Source/PromoSticker/CornerPlacement.swift
+++ b/Sources/Source/PromoSticker/CornerPlacement.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-enum CornerPlacement {
+public enum CornerPlacement {
     case topLeading, bottomLeading, bottomTrailing, topTrailing
 
     var topLeadingRadius: CGFloat {

--- a/Sources/Source/PromoSticker/CornerPlacement.swift
+++ b/Sources/Source/PromoSticker/CornerPlacement.swift
@@ -18,7 +18,7 @@ public enum CornerPlacement {
         }
     }
 
-    var bottomLeadingRadiuus: CGFloat {
+    var bottomLeadingRadius: CGFloat {
         switch self {
         case .topLeading:
             0

--- a/Sources/Source/PromoSticker/CornerPlacement.swift
+++ b/Sources/Source/PromoSticker/CornerPlacement.swift
@@ -1,0 +1,60 @@
+//
+
+import Foundation
+
+enum CornerPlacement {
+    case topLeading, bottomLeading, bottomTrailing, topTrailing
+
+    var topLeadingRadius: CGFloat {
+        switch self {
+        case .topLeading:
+            4
+        case .bottomLeading:
+            0
+        case .bottomTrailing:
+            4
+        case .topTrailing:
+            0
+        }
+    }
+
+    var bottomLeadingRadiuus: CGFloat {
+        switch self {
+        case .topLeading:
+            0
+        case .bottomLeading:
+            4
+        case .bottomTrailing:
+            0
+        case .topTrailing:
+            4
+        }
+    }
+
+
+    var bottomTrailingRadius: CGFloat {
+        switch self {
+        case .topLeading:
+            4
+        case .bottomLeading:
+            0
+        case .bottomTrailing:
+            4
+        case .topTrailing:
+            0
+        }
+    }
+
+    var topTrailingRadius: CGFloat {
+        switch self {
+        case .topLeading:
+            0
+        case .bottomLeading:
+            4
+        case .bottomTrailing:
+            0
+        case .topTrailing:
+            4
+        }
+    }
+}

--- a/Sources/Source/PromoSticker/PromoStickerSize.swift
+++ b/Sources/Source/PromoSticker/PromoStickerSize.swift
@@ -1,5 +1,5 @@
 //
 
-enum PromoStickerSize {
+public enum PromoStickerSize {
     case small, large
 }

--- a/Sources/Source/PromoSticker/PromoStickerSize.swift
+++ b/Sources/Source/PromoSticker/PromoStickerSize.swift
@@ -1,0 +1,5 @@
+//
+
+enum PromoStickerSize {
+    case small, large
+}

--- a/Sources/Source/PromoSticker/PromoStickerTheme.swift
+++ b/Sources/Source/PromoSticker/PromoStickerTheme.swift
@@ -15,29 +15,69 @@ public struct PromoStickerTheme {
 public extension PromoStickerTheme {
     static var blue: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(ColorPalette.neutral97),
-            backgroundColor: Color(ColorPalette.sport400)
+            foregroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.neutral97,
+                    dark: ColorPalette.sport300
+                )
+            ),
+            backgroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.sport400,
+                    dark: ColorPalette.sport800
+                )
+            )
         )
     }
 
     static var red: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(ColorPalette.neutral97),
-            backgroundColor: Color(ColorPalette.news400)
+            foregroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.neutral97,
+                    dark: ColorPalette.news300
+                )
+            ),
+            backgroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.news400,
+                    dark: ColorPalette.news800
+                )
+            )
         )
     }
 
     static var purple: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(ColorPalette.neutral97),
-            backgroundColor: Color(ColorPalette.lifestyle400)
+            foregroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.neutral97,
+                    dark: ColorPalette.lifestyle300
+                )
+            ),
+            backgroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.lifestyle400,
+                    dark: ColorPalette.lifestyle800
+                )
+            )
         )
     }
 
     static var green: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(ColorPalette.neutral97),
-            backgroundColor: Color(ColorPalette.labs200)
+            foregroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.neutral97,
+                    dark: ColorPalette.labs200
+                )
+            ),
+            backgroundColor: Color(
+                .dynamicColor(
+                    light: ColorPalette.labs200,
+                    dark: ColorPalette.labs700
+                )
+            )
         )
     }
 }

--- a/Sources/Source/PromoSticker/PromoStickerTheme.swift
+++ b/Sources/Source/PromoSticker/PromoStickerTheme.swift
@@ -5,6 +5,11 @@ import SwiftUI
 public struct PromoStickerTheme {
     let foregroundColor: Color
     let backgroundColor: Color
+
+    public init(foregroundColor: Color, backgroundColor: Color) {
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+    }
 }
 
 public extension PromoStickerTheme {

--- a/Sources/Source/PromoSticker/PromoStickerTheme.swift
+++ b/Sources/Source/PromoSticker/PromoStickerTheme.swift
@@ -1,0 +1,38 @@
+//
+
+import SwiftUI
+
+struct PromoStickerTheme {
+    let foregroundColor: Color
+    let backgroundColor: Color
+}
+
+extension PromoStickerTheme {
+    static var blue: PromoStickerTheme {
+        PromoStickerTheme(
+            foregroundColor: Color(uiColor: ColorPalette.neutral97),
+            backgroundColor: Color(uiColor: ColorPalette.sport400)
+        )
+    }
+
+    static var red: PromoStickerTheme {
+        PromoStickerTheme(
+            foregroundColor: Color(uiColor: ColorPalette.neutral97),
+            backgroundColor: Color(uiColor: ColorPalette.news400)
+        )
+    }
+
+    static var purple: PromoStickerTheme {
+        PromoStickerTheme(
+            foregroundColor: Color(uiColor: ColorPalette.neutral97),
+            backgroundColor: Color(uiColor: ColorPalette.lifestyle400)
+        )
+    }
+
+    static var green: PromoStickerTheme {
+        PromoStickerTheme(
+            foregroundColor: Color(uiColor: ColorPalette.neutral97),
+            backgroundColor: Color(uiColor: ColorPalette.labs200)
+        )
+    }
+}

--- a/Sources/Source/PromoSticker/PromoStickerTheme.swift
+++ b/Sources/Source/PromoSticker/PromoStickerTheme.swift
@@ -2,12 +2,12 @@
 
 import SwiftUI
 
-struct PromoStickerTheme {
+public struct PromoStickerTheme {
     let foregroundColor: Color
     let backgroundColor: Color
 }
 
-extension PromoStickerTheme {
+public extension PromoStickerTheme {
     static var blue: PromoStickerTheme {
         PromoStickerTheme(
             foregroundColor: Color(uiColor: ColorPalette.neutral97),

--- a/Sources/Source/PromoSticker/PromoStickerTheme.swift
+++ b/Sources/Source/PromoSticker/PromoStickerTheme.swift
@@ -15,29 +15,29 @@ public struct PromoStickerTheme {
 public extension PromoStickerTheme {
     static var blue: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(uiColor: ColorPalette.neutral97),
-            backgroundColor: Color(uiColor: ColorPalette.sport400)
+            foregroundColor: Color(ColorPalette.neutral97),
+            backgroundColor: Color(ColorPalette.sport400)
         )
     }
 
     static var red: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(uiColor: ColorPalette.neutral97),
-            backgroundColor: Color(uiColor: ColorPalette.news400)
+            foregroundColor: Color(ColorPalette.neutral97),
+            backgroundColor: Color(ColorPalette.news400)
         )
     }
 
     static var purple: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(uiColor: ColorPalette.neutral97),
-            backgroundColor: Color(uiColor: ColorPalette.lifestyle400)
+            foregroundColor: Color(ColorPalette.neutral97),
+            backgroundColor: Color(ColorPalette.lifestyle400)
         )
     }
 
     static var green: PromoStickerTheme {
         PromoStickerTheme(
-            foregroundColor: Color(uiColor: ColorPalette.neutral97),
-            backgroundColor: Color(uiColor: ColorPalette.labs200)
+            foregroundColor: Color(ColorPalette.neutral97),
+            backgroundColor: Color(ColorPalette.labs200)
         )
     }
 }

--- a/Sources/Source/PromoSticker/PromoStickerView.swift
+++ b/Sources/Source/PromoSticker/PromoStickerView.swift
@@ -6,8 +6,7 @@ struct PromoStickerView: View {
 
     let text: String
     let size: PromoStickerSize
-    let foregroundColor: Color
-    let backgroundColor: Color
+    let theme: PromoStickerTheme
     var alignment: CornerPlacement?
 
     var body: some View {
@@ -16,15 +15,17 @@ struct PromoStickerView: View {
             .padding(.horizontal, size == .small ? 4 : 8)
             .padding(.vertical, size == .small ? 4 : 6.5)
             .background {
-                roundedRectangle
-                    .fill(backgroundColor)
+                container
+                    .fill(theme.backgroundColor)
+
 
             }
-            .foregroundStyle(foregroundColor)
+            .foregroundStyle(theme.foregroundColor)
+            // dynamic type not supported on this component for now...
             .dynamicTypeSize(.medium)
     }
 
-    private var roundedRectangle: AnyShape {
+    private var container: AnyShape {
         if let alignment {
             AnyShape(
                 UnevenRoundedRectangle(
@@ -46,97 +47,84 @@ struct PromoStickerView: View {
             PromoStickerView(
                 text: "Save 30%",
                 size: .small,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.sport400),
+                theme: .red
             )
             PromoStickerView(
                 text: "Save 30%",
                 size: .large,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.sport400),
+                theme: .red
             )
         }
         HStack(alignment: .top) {
             PromoStickerView(
                 text: "Save 30%",
                 size: .small,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.news400),
+                theme: .blue
             )
             PromoStickerView(
                 text: "Save 30%",
                 size: .large,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.news400),
+                theme: .blue
             )
         }
         HStack(alignment: .top) {
             PromoStickerView(
                 text: "Save 30%",
                 size: .small,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.lifestyle400),
+                theme: .purple
             )
             PromoStickerView(
                 text: "Save 30%",
                 size: .large,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.lifestyle400),
+                theme: .purple
             )
         }
         HStack(alignment: .top) {
             PromoStickerView(
                 text: "Save 30%",
                 size: .small,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.labs200),
+                theme: .green
             )
             PromoStickerView(
                 text: "Save 30%",
                 size: .large,
-                foregroundColor: Color(uiColor: ColorPalette.neutral97),
-                backgroundColor: Color(uiColor: ColorPalette.labs200),
+                theme: .green
             )
         }
         Divider()
         RoundedRectangle(cornerRadius: 4)
             .strokeBorder(lineWidth: 1)
             .frame(width: 150, height: 200)
-            .foregroundColor(.blue)
-
+            .foregroundColor(Color(uiColor: ColorPalette.sport400))
             .overlay(alignment: .bottomTrailing) {
                 PromoStickerView(
-                    text: "Beta",
+                    text: "B trailing",
                     size: .small,
-                    foregroundColor: .blue,
-                    backgroundColor: .blue,
+                    theme: .blue,
                     alignment: .bottomTrailing
                 )
             }
             .overlay(alignment: .topLeading) {
                 PromoStickerView(
-                    text: "Beta",
+                    text: "T leading",
                     size: .small,
-                    foregroundColor: .blue,
-                    backgroundColor: .blue,
+                    theme: .blue,
                     alignment: .topLeading
                 )
             }
             .overlay(alignment: .bottomLeading) {
                 PromoStickerView(
-                    text: "Beta",
+                    text: "B leading",
                     size: .small,
-                    foregroundColor: .blue,
-                    backgroundColor: .blue,
+                    theme: .blue,
                     alignment: .bottomLeading
                 )
             }
             .overlay(alignment: .topTrailing) {
                 PromoStickerView(
-                    text: "Beta",
+                    text: "T trailing",
                     size: .small,
-                    foregroundColor: .blue,
-                    backgroundColor: .blue,
+                    theme: .blue,
                     alignment: .topTrailing
                 )
             }

--- a/Sources/Source/PromoSticker/PromoStickerView.swift
+++ b/Sources/Source/PromoSticker/PromoStickerView.swift
@@ -1,0 +1,145 @@
+//
+
+import SwiftUI
+
+struct PromoStickerView: View {
+
+    let text: String
+    let size: PromoStickerSize
+    let foregroundColor: Color
+    let backgroundColor: Color
+    var alignment: CornerPlacement?
+
+    var body: some View {
+        Text(text)
+            .font(size == .large ? Typography.textSansBld15 : Typography.textSansBld12)
+            .padding(.horizontal, size == .small ? 4 : 8)
+            .padding(.vertical, size == .small ? 4 : 6.5)
+            .background {
+                roundedRectangle
+                    .fill(backgroundColor)
+
+            }
+            .foregroundStyle(foregroundColor)
+            .dynamicTypeSize(.medium)
+    }
+
+    private var roundedRectangle: AnyShape {
+        if let alignment {
+            AnyShape(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: alignment.topLeadingRadius,
+                    bottomLeadingRadius: alignment.bottomLeadingRadiuus,
+                    bottomTrailingRadius: alignment.bottomTrailingRadius,
+                    topTrailingRadius: alignment.topTrailingRadius
+                )
+            )
+        } else {
+            AnyShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        HStack(alignment: .top) {
+            PromoStickerView(
+                text: "Save 30%",
+                size: .small,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.sport400),
+            )
+            PromoStickerView(
+                text: "Save 30%",
+                size: .large,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.sport400),
+            )
+        }
+        HStack(alignment: .top) {
+            PromoStickerView(
+                text: "Save 30%",
+                size: .small,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.news400),
+            )
+            PromoStickerView(
+                text: "Save 30%",
+                size: .large,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.news400),
+            )
+        }
+        HStack(alignment: .top) {
+            PromoStickerView(
+                text: "Save 30%",
+                size: .small,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.lifestyle400),
+            )
+            PromoStickerView(
+                text: "Save 30%",
+                size: .large,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.lifestyle400),
+            )
+        }
+        HStack(alignment: .top) {
+            PromoStickerView(
+                text: "Save 30%",
+                size: .small,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.labs200),
+            )
+            PromoStickerView(
+                text: "Save 30%",
+                size: .large,
+                foregroundColor: Color(uiColor: ColorPalette.neutral97),
+                backgroundColor: Color(uiColor: ColorPalette.labs200),
+            )
+        }
+        Divider()
+        RoundedRectangle(cornerRadius: 4)
+            .strokeBorder(lineWidth: 1)
+            .frame(width: 150, height: 200)
+            .foregroundColor(.blue)
+
+            .overlay(alignment: .bottomTrailing) {
+                PromoStickerView(
+                    text: "Beta",
+                    size: .small,
+                    foregroundColor: .blue,
+                    backgroundColor: .blue,
+                    alignment: .bottomTrailing
+                )
+            }
+            .overlay(alignment: .topLeading) {
+                PromoStickerView(
+                    text: "Beta",
+                    size: .small,
+                    foregroundColor: .blue,
+                    backgroundColor: .blue,
+                    alignment: .topLeading
+                )
+            }
+            .overlay(alignment: .bottomLeading) {
+                PromoStickerView(
+                    text: "Beta",
+                    size: .small,
+                    foregroundColor: .blue,
+                    backgroundColor: .blue,
+                    alignment: .bottomLeading
+                )
+            }
+            .overlay(alignment: .topTrailing) {
+                PromoStickerView(
+                    text: "Beta",
+                    size: .small,
+                    foregroundColor: .blue,
+                    backgroundColor: .blue,
+                    alignment: .topTrailing
+                )
+            }
+    }
+    .previewFonts()
+}

--- a/Sources/Source/PromoSticker/PromoStickerView.swift
+++ b/Sources/Source/PromoSticker/PromoStickerView.swift
@@ -30,7 +30,6 @@ public struct PromoStickerView: View {
                 container
                     .fill(theme.backgroundColor)
 
-
             }
             .foregroundStyle(theme.foregroundColor)
             // dynamic type not supported on this component for now...

--- a/Sources/Source/PromoSticker/PromoStickerView.swift
+++ b/Sources/Source/PromoSticker/PromoStickerView.swift
@@ -7,7 +7,7 @@ public struct PromoStickerView: View {
     let text: String
     let size: PromoStickerSize
     let theme: PromoStickerTheme
-    var alignment: CornerPlacement?
+    let placement: CornerPlacement?
 
     public init(
         text: String,
@@ -18,7 +18,7 @@ public struct PromoStickerView: View {
         self.text = text
         self.size = size
         self.theme = theme
-        self.alignment = alignment
+        self.placement = alignment
     }
 
     public var body: some View {
@@ -38,13 +38,13 @@ public struct PromoStickerView: View {
     }
 
     private var container: AnyShape {
-        if let alignment {
+        if let placement {
             AnyShape(
                 UnevenRoundedRectangle(
-                    topLeadingRadius: alignment.topLeadingRadius,
-                    bottomLeadingRadius: alignment.bottomLeadingRadiuus,
-                    bottomTrailingRadius: alignment.bottomTrailingRadius,
-                    topTrailingRadius: alignment.topTrailingRadius
+                    topLeadingRadius: placement.topLeadingRadius,
+                    bottomLeadingRadius: placement.bottomLeadingRadius,
+                    bottomTrailingRadius: placement.bottomTrailingRadius,
+                    topTrailingRadius: placement.topTrailingRadius
                 )
             )
         } else {
@@ -107,7 +107,7 @@ public struct PromoStickerView: View {
         RoundedRectangle(cornerRadius: 4)
             .strokeBorder(lineWidth: 1)
             .frame(width: 150, height: 200)
-            .foregroundColor(Color(uiColor: ColorPalette.sport400))
+            .foregroundColor(Color(ColorPalette.sport400))
             .overlay(alignment: .bottomTrailing) {
                 PromoStickerView(
                     text: "B trailing",

--- a/Sources/Source/PromoSticker/PromoStickerView.swift
+++ b/Sources/Source/PromoSticker/PromoStickerView.swift
@@ -2,14 +2,26 @@
 
 import SwiftUI
 
-struct PromoStickerView: View {
+public struct PromoStickerView: View {
 
     let text: String
     let size: PromoStickerSize
     let theme: PromoStickerTheme
     var alignment: CornerPlacement?
 
-    var body: some View {
+    public init(
+        text: String,
+        size: PromoStickerSize,
+        theme: PromoStickerTheme,
+        alignment: CornerPlacement? = nil
+    ) {
+        self.text = text
+        self.size = size
+        self.theme = theme
+        self.alignment = alignment
+    }
+
+    public var body: some View {
         Text(text)
             .font(size == .large ? Typography.textSansBld15 : Typography.textSansBld12)
             .padding(.horizontal, size == .small ? 4 : 8)


### PR DESCRIPTION
#### Description

**Figma**: https://www.figma.com/design/kSmjgtoTWiG8N7HXxFoGEE/%E2%97%90-Apps-library?node-id=15923-91&p=f&t=ZFSlkDxFTvXxG3EC-0

Here we add the Promo Sticker component and its four default styles. Also added to the Sourcy app. PR of its use in the live app [here](https://github.com/guardian/ios-live/pull/10082).

#### Testing notes/instructions:

A screenshot should suffice in this case but feel free to use the promo sticker builder in the Sourcy app. 

#### Checklist
- [x] Changes have been checked by the developer
- [x] Changes have been checked by the reviewers
- [ ] Unit tested

##### Recommended reviewers

- Design review for UI changes from @guardian/design-system
- Code review from @guardian/android-developers or @guardian/ios-developers
- Optional code/API review from @guardian/client-side-infra

#### For pull requests introducing UI changes:

- [ ] Sign-off by Design: <!-- Tag one or more designers, or mark as N/A; please DO NOT delete -->
- [ ] Dark Mode <!-- Verify that colours are correct and everything is legible -->
- [ ] Tablet <!-- If relevant, make sure you check the layout on iPad/Android tablet -->
- [ ] Accessibility (e.g. VoiceOver): <!-- Specify whether it was tested, or mark as N/A; please DO NOT delete -->

##### Screenshots or videos:

<!-- If you have multiple before/after screenshots, use the following table; otherwise remove -->
<!-- Put a markdown-uploaded image on each side of the pipe in the last row; repeat if necessary -->
<!-- Do not delete this ↓ blank line or the table won't work -->

## Component 

| Light | Dark |
| --- | --- |
|<img width="336" height="725" alt="Screenshot 2026-07-03 at 18 48 43" src="https://github.com/user-attachments/assets/abdc46df-84ae-4292-9c4f-674a71d95a89" />|<img width="394" height="713" alt="Screenshot 2026-07-03 at 18 48 50" src="https://github.com/user-attachments/assets/80f6453f-3ce3-488d-850d-9f7e8c1a2c1d" />|

## Sourcy

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-03 at 12 38 52" src="https://github.com/user-attachments/assets/ba01303d-25ed-4bd9-9606-d3045f8e6b89" />

<!-- Do not delete this ↑ blank line or the table won't work -->
