### PR TITLE
Change gradle release workflow commit to test API file fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release
     if: github.repository == 'guardian/source-apps'
     permissions: { contents: write, pull-requests: write }
-    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@5b87f1887c874490c8a04f6a7bb56a14294ebd0e
+    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@c58326089181de7f6c803e15834663b6a5270b92
     with:
       SOURCE_DIR: 'android'
       MODULES: 'source'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release
     if: github.repository == 'guardian/source-apps'
     permissions: { contents: write, pull-requests: write }
-    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@c58326089181de7f6c803e15834663b6a5270b92
+    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@ab/health/read-api-file-content-from-file-not-from-variable
     with:
       SOURCE_DIR: 'android'
       MODULES: 'source'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release
     if: github.repository == 'guardian/source-apps'
     permissions: { contents: write, pull-requests: write }
-    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@ab/health/read-api-file-content-from-file-not-from-variable
+    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@1829c7a3152b70a65ab1e1f81ca44463f11708fb
     with:
       SOURCE_DIR: 'android'
       MODULES: 'source'


### PR DESCRIPTION
#### Description

Update the Gradle release workflow. The current workflow breaks when the API file gets too long, as it has on Source.

See the release repository PR for more details: https://github.com/guardian/gha-gradle-library-release-workflow/pull/12

#### Testing notes/instructions:

Did a test release - see the generated comment below.

